### PR TITLE
Imported core and testing meeting notes

### DIFF
--- a/minutes/core/2011-01-04.md
+++ b/minutes/core/2011-01-04.md
@@ -1,0 +1,75 @@
+Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Time: Tuesday January 4, 2011 at 9pm ET
+
+Official Agenda:
+
+AGENDA for Tue Jan 4 9pm jQuery Meeting  
+ Duration is 1 hour, so please keep comments brief and to the point to
+facilitate discussion on all topics
+
+CORE
+
+-   1.5 roadmap overview: what is happening, what is not, etc. (1 min)
+
+-   Alpha, RC, final release schedule: current blockers, target dates (3
+    min)
+
+-   Deferred API [5]
+
+-   Status of attr rewrite (5 min)/join
+
+-   Status of XML/SVG support (5 min)
+
+-   Ajax rewrite: any new issues? questions? (10 min)
+
+-   jaubourg mentioned something to win filesize back by making the
+    returned Deferred non-resuable; status of this?
+
+-   CommonJS: what should we adhere to, what is our level of
+    involvement, what kind of outreach should there be [4][7] (10 min)
+
+-   File  size increase: jQuery is 2kB larger with the new ajax
+    functionality. Is  there anywhere we can win some of this back? (5
+    min)
+
+-   Sizzle changes (5 min)
+
+-   Not part of jQuery repo; core committers do not have access
+
+-   Unit  tests in Sizzle get out of sync with unit tests in jQuery;
+    jeresig has a  script to do merging, but is there a better option?
+
+-   Wrapping plain JS objects: what is our official policy? [6] (5 min)
+
+-   Other tickets: wontfix/unresolved issues worth discussing? (5 min)
+
+DOCS & INFRASTRUCTURE
+
+-   Cluster configuration state (1 min)
+
+-   State of work on plugins site (1 min)
+
+-   Plans for documentation site (3 min)
+
+-   Learning site plans (1 min)
+
+If there is any time left, UI folks can talk about whatever too, like
+the new grid thing
+
+Resource links:  
+
+[1][http://blog.jquery.com/2010/12/28/jquery-community-updates-for-december-2010/](http://blog.jquery.com/2010/12/28/jquery-community-updates-for-december-2010/)  
+
+[2][http://bugs.jquery.com/query?status=](http://bugs.jquery.com/query?status=)!closed&milestone=1.4.5&order=priority
+— tickets for a hypothetical 1.4.5 (stopgap if 1.5 slips)  
+
+[3][http://bugs.jquery.com/query?status=](http://bugs.jquery.com/query?status=)!closed&milestone=1.5&order=priority
+— tickets for 1.5 release  
+
+[4][http://tagneto.blogspot.com/2010/12/standards-and-proposals-for-javascript.html](http://tagneto.blogspot.com/2010/12/standards-and-proposals-for-javascript.html)  
+
+[5][http://blog.rebeccamurphey.com/deferreds-coming-to-jquery](http://blog.rebeccamurphey.com/deferreds-coming-to-jquery)  
+
+[6][http://bugs.jquery.com/ticket/7818](http://bugs.jquery.com/ticket/7818)  
+ [7][http://commonjs.org](http://commonjs.org/)

--- a/minutes/core/2011-01-10.md
+++ b/minutes/core/2011-01-10.md
@@ -1,0 +1,127 @@
+Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Time: Monday January 10, 2011 at Noon ET
+
+Official Agenda:
+
+AGENDA for Mon Jan 10 Noon jQuery Meeting  
+ Duration is 1 hour, so please keep comments brief and to the point to
+facilitate discussion on all topics
+
+CORE
+
+-   Status of jQuery 1.5 Alpha 1
+
+-   To be released Jan 14th
+
+-   Ajax Rewrite Status
+
+-   (See below)
+
+-   Julian/Karl: Get documentation going.
+
+-   Deferreds Status
+
+-   (See below)
+
+-   Julian/Karl: Get documentation going.
+
+-   Julian: Implement auto-new.
+
+-   jQuery.Deferred() -\> new jQuery.Deferred();
+
+-   Look at things like \$().animate().then() in 1.6
+
+-   Subclassing Status
+
+-   Yehuda: Land code in repo.
+
+-   Deadlyicon/Karl: Needs Documentation
+
+-   Generic Subclassing – \> tabled till 1.6
+
+-   Sizzle tweaks Status
+
+-   John: Did a deep review of work needed, started to make some
+    headway. Breaking out :not(a:first) is going to be a significant
+    rewrite and will require a lot of time – beyond what we can likely
+    tackle in this release. Want to recommend holding off until later.
+
+-   Additional notes: We are moving toward sizzle only supporting valid
+    qSA selectors and “offloading” any non-qSA (set filtering, custom)
+    selectors into jQuery but we’ll probably hold off until 1.6 for this
+    re-write
+
+-   Handle CSRF tweaks from Mozilla
+
+-   [http://bugs.jquery.com/ticket/7371](http://bugs.jquery.com/ticket/7371)
+
+-   Switch to new file compressor – UglifyJS
+
+-   Snover is landing this.
+
+-   Browser Support
+
+-   Opera 11 and 10.6 (dropping 10.6 in next release). For mobile we
+    support Mini and Mobile current.
+
+-   Other tickets: wontfix/unresolved issues worth discussing? (5 min)
+
+-   Todo: Fix Sizzle Quoting Issue
+
+-   [http://bugs.jquery.com/ticket/7539](http://bugs.jquery.com/ticket/7539)
+
+[](http://bugs.jquery.com/ticket/7539)  
+ Resource links:  
+
+[1][http://blog.jquery.com/2010/12/28/jquery-community-updates-for-december-2010/](http://blog.jquery.com/2010/12/28/jquery-community-updates-for-december-2010/)  
+
+[2][http://bugs.jquery.com/query?status=](http://bugs.jquery.com/query?status=)!closed&milestone=1.4.5&order=priority
+— tickets for a hypothetical 1.4.5 (stopgap if 1.5 slips)  
+
+[3][http://bugs.jquery.com/query?status=](http://bugs.jquery.com/query?status=)!closed&milestone=1.5&order=priority
+— tickets for 1.5 release  
+
+[4][http://tagneto.blogspot.com/2010/12/standards-and-proposals-for-javascript.html](http://tagneto.blogspot.com/2010/12/standards-and-proposals-for-javascript.html)  
+
+[5][http://blog.rebeccamurphey.com/deferreds-coming-to-jquery](http://blog.rebeccamurphey.com/deferreds-coming-to-jquery)  
+
+[6][http://bugs.jquery.com/ticket/7818](http://bugs.jquery.com/ticket/7818)  
+ [7][http://commonjs.org](http://commonjs.org/)  
+ [](http://commonjs.org/)  
+ [](http://commonjs.org/)  
+ Deferreds status:  
+ - Promise/A compliant
+([http://wiki.commonjs.org/wiki/Promises/A](http://wiki.commonjs.org/wiki/Promises/A)
+)  
+ - Used internally for ajax and \$.fn.ready ( actually internal
+\_Deferred object )  
+ - \$.when is a base skeleton there are some discussions about how it
+should work and what it should accept as parameters: multiple for joined
+promise, etc)  
+ - Also, I’ve had some interesting discussions regarding adding a
+lastPromise property to jQuery objects that would allow to observe when
+the latest asynchronous event on the collection is done, allowing things
+like:  
+ + \$.when( \$( … ).load( … ) ).then( … )  
+ + \$.when( \$( … ).animate( … ) ).then( … )
+
+Ajax Rewrite Status:  
+ - Stable now (both code-wise and file structure-wise — waiting for
+feedback from Yehuda regarding the prefilter that shouldn’t be named to
+incorporate it)  
+ - Still reviewing tickets to see which are already fixed and fixing
+others as I (jaubourg) go  
+ - Snover will kill me if I don’t handle my spacing habit and reformat
+all the code to the jQuery standard (I tend to add spaces around
+everything)  
+ - On a side-note, \$.parseXML has been extracted from ajax and
+published in core. Still need unit testing for this but it passes unit
+tests in ajax (indirectly though and not as thouroughly as it should)  
+ - Also, there’s a unit test that seems to randomly fail in FF4b8. This
+seems to be due to some quirk in the xhr implementation that the new xhr
+pooling code triggers. Still need to make a minimal test case and tell
+the FF devs.  
+ - NEEDS DOCUMENTATION. Given the scope I’d really appreciate if I could
+sit with Karl on skype or something so that someone helps me in
+documenting this beast.

--- a/minutes/core/2011-01-17.md
+++ b/minutes/core/2011-01-17.md
@@ -1,0 +1,114 @@
+Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Time: Monday January 17, 2011 at Noon ET
+
+Official Agenda:
+
+AGENDA for Mon Jan 17 Noon jQuery Meeting  
+ Duration is 1 hour, so please keep comments brief and to the point to
+facilitate discussion on all topics
+
+CORE
+
+-   jQuery 1.5 Beta 1 Done
+    -   Bugs Team: Need to make sure that recent bugs are tracked and
+        turned into blockers.
+
+-   Status of jQuery 1.5 RC
+    -   Ajax Rewrite Status
+        -   Julian working on docs with Karl
+            -   http://oksoclap.com/jq-api-ajax
+
+        -   Should be feature complete now
+        -   Julian doesn’t see any new major issues
+        -   Got a review by Snover
+            -   Some code needs to be moved around a bit, Julian looking
+                in to.
+
+    -   Deferreds Status
+        -   Implemented \$.when() joined statements
+        -   Added some unit tests and added some fixes for the promise
+            method
+        -   Julian considers them to be done
+        -   Dave is working on docs
+            -   Docs/tutorial are important for people to be able to
+                test from
+            -   If possible to get something together pre-release so we
+                have time for more people to test that would be great.
+
+        -   Evaluate if we should expose a ready promise for 1.6
+
+    -   Subclassing Status
+        -   Adding a new isolated mode today (would optionally protect
+            from jqueries triggering each others events)
+        -   Draft docs for subclass are up on the API site
+            -   http://api.jquery.com/jQuery.subclass/
+
+        -   Possible enhancement:
+            -   [http://bugs.jquery.com/ticket/7979](http://bugs.jquery.com/ticket/7979)
+            -   Yehuda will look into this today
+
+    -   Blockers:
+        -   [http://bugs.jquery.com/report/74](http://bugs.jquery.com/report/74)
+        -   Selector parsing bugs (john) (done)
+            -   [http://bugs.jquery.com/ticket/3778](http://bugs.jquery.com/ticket/3778)
+            -   [http://bugs.jquery.com/ticket/6093](http://bugs.jquery.com/ticket/6093)
+            -   [http://bugs.jquery.com/ticket/7216](http://bugs.jquery.com/ticket/7216)
+            -   [http://bugs.jquery.com/ticket/7539](http://bugs.jquery.com/ticket/7539)
+            -   John: Going to land attribute quoting fix, others look
+                lower priority
+
+        -   .data() and internal data – Data collision patch conceptual
+            review (snover) (done)
+            -   [http://bugs.jquery.com/ticket/6968](http://bugs.jquery.com/ticket/6968)
+            -   [http://bugs.jquery.com/ticket/7818](http://bugs.jquery.com/ticket/7818)
+            -   [http://bugs.jquery.com/ticket/7840](http://bugs.jquery.com/ticket/7840)
+                (sort of)21
+            -   Status: Land pull request from snover.
+                -   Add duck punch for .data(“events”)
+
+        -   CSP (john) (done)
+            -   [http://bugs.jquery.com/ticket/7371](http://bugs.jquery.com/ticket/7371)
+            -   John: Definitely going to land this week
+
+        -   UglifyJS patch review (snover) (done)
+            -   [http://bugs.jquery.com/ticket/7973](http://bugs.jquery.com/ticket/7973)
+            -   Status: Land pull request, but add docs for Windows
+                build instructions
+
+        -   Misc
+            -   [http://bugs.jquery.com/ticket/7608](http://bugs.jquery.com/ticket/7608)
+                (Opera animation issue – rick) (done)
+                -   Ready to land.
+
+            -   [http://bugs.jquery.com/ticket/7340](http://bugs.jquery.com/ticket/7340)
+                (event bubbling issue – dave)
+                -   Status?
+
+            -   [http://bugs.jquery.com/ticket/7986](http://bugs.jquery.com/ticket/7986)
+                (boxModel issue – unassigned)
+                -   Not fixing, bumping
+
+        -   Needs test case or bug filed against Chrome (wycats):
+            -   [https://github.com/jquery/jquery/commit/52a02383fa521c51d9996a46f03a7080dd825f11](https://github.com/jquery/jquery/commit/52a02383fa521c51d9996a46f03a7080dd825f11)
+            -   Looks like an unneeded fix for a Chrome dev version
+            -   We need to file a bug with the Chrome team (done) and
+                update commit message to be clearer as to what happened
+
+PLUGINS
+
+-   Timeline for official plugin B2s (tmpl, datalink, global). End of
+    Jan reasonable? Impacts UI Grid timeline.
+-   jquery-global
+    -   Joern moved functions from \$.\* to \$.global.\*
+    -   Proposal to create globalization interface methods (such as
+        \$.format and \$.parseFloat, \$.parseDate) at \$.\* and leave
+        jquery-global implementations in \$.global.\*. This would allow
+        for alternate implementations while still providing a standard
+        interface for plugin developers to target/use. Including
+        jquery.global.js would import implementation and alias/proxy
+        \$.\* to \$.global.\*. For this to be effective, the \$.\*
+        methods dummy/interface methods would need to be added to jQuery
+        core so all plugin authors could make use of them.
+
+

--- a/minutes/core/2011-01-24.md
+++ b/minutes/core/2011-01-24.md
@@ -1,0 +1,48 @@
+Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Time: Monday January 24, 2011 at Noon ET
+
+Official Agenda:
+
+AGENDA for Mon Jan 24 Noon jQuery Meeting  
+ Duration is 1 hour, so please keep comments brief and to the point to
+facilitate discussion on all topics
+
+CORE
+
+-   jQuery 1.5 RC Status
+    -   Should come out today or tomorrow, at the latest.
+
+-   Blockers
+    -   Full List
+        -   [http://bugs.jquery.com/report/74](http://bugs.jquery.com/report/74)
+
+    -   [\#8036 .closest(selectorArray) returns
+        duplicates](http://bugs.jquery.com/ticket/8036) (Dave)
+        -   John:  This is the intended behavior – it returns elements
+            for each selector.
+        -   Status: Closed, invalid
+
+    -   [\#7340 .focus() not triggering focusin event for .live binding
+        (1.4.3)?](http://bugs.jquery.com/ticket/7340) (Dave)
+        -   Will likely require a re-architecture
+        -   Status: Push to 1.6
+
+    -   [\#7992 jQuery 1.5b1 is slower to remove elements than
+        1.4.2](http://bugs.jquery.com/ticket/7992) (Colin and Rick)
+        -   Looks like the jsfiddle perf was poorly constructed
+        -   Need to make a new perf test case and doubly-verify
+
+-   Ajax Rewrite
+    -   Documentation
+        -   [http://oksoclap.com/jq-api-ajax](http://oksoclap.com/jq-api-ajax)
+
+-   Deferreds
+    -   Documentation
+        -   [http://api.jquery.com/category/deferred-object/](http://api.jquery.com/category/deferred-object/)
+
+-   Subclassing
+    -   Documentation
+        -   [http://api.jquery.com/jQuery.subclass/](http://api.jquery.com/jQuery.subclass/)
+
+

--- a/minutes/core/2011-01-31.md
+++ b/minutes/core/2011-01-31.md
@@ -1,0 +1,1 @@
+jQuery 1.5 Released!

--- a/minutes/core/2011-02-07.md
+++ b/minutes/core/2011-02-07.md
@@ -1,0 +1,51 @@
+Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Time: Noon ET
+
+Official Agenda:
+
+AGENDA for jQuery Meeting  
+ Duration is 1 hour, so please keep comments brief and to the point to
+facilitate discussion on all topics
+
+CORE
+
+-   1.5 release postmortem
+    -   Docs were only about half done.
+        -   Feature docs should be done in order to push the first beta.
+        -   Should open separate blocker tickets for them.
+        -   Make them a dependency of the main feature.
+
+    -   Release notes weren’t ready in advance, had to be written the
+        day of.
+    -   We should have a clear grid of features and who is working on
+        what along with statuses of tests, docs, etc.
+
+-   Setting date for 1.6 roadmap meeting
+    -   Proposal: Normal meeting time, Feb 28th
+    -   John: Need to set up document for people to submit to.
+
+-   jQuery 1.5.1 Status
+    -   RC: Feb 18th.
+    -   Final: Feb 24th.
+    -   Blockers  
+         [http://bugs.jquery.com/report/75](http://bugs.jquery.com/report/75)
+
+-   Dev Branches / Stable Branches
+    -   All current 1.5.x dev is done against master
+    -   We keep separate branches for each major feature/rewrite
+
+-   Flagging bugs that are browser bugs
+    -   Assigning bugs to a username that matches the browser?
+        -   browser-safari
+        -   browser-chrome
+        -   browser-webkit
+        -   browser-msie
+        -   browser-firefox
+        -   browser-opera
+
+    -   Assign them the ‘browserbug’ tag.
+
+-   Time permitting: Discuss possible requirement of running jQuery UI
+    tests.
+

--- a/minutes/core/2011-02-14.md
+++ b/minutes/core/2011-02-14.md
@@ -1,0 +1,44 @@
+Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Time: Noon ET
+
+Official Agenda:
+
+AGENDA for jQuery Meeting  
+ Duration is 1 hour, so please keep comments brief and to the point to
+facilitate discussion on all topics
+
+CORE
+
+-   1.5.1 Status
+    -   RC is on the 18th, this Friday
+    -   Blockers:
+        [http://bugs.jquery.com/report/75](http://bugs.jquery.com/report/75)
+        -   [live(‘click’) does not fire when when live(‘submit’) is
+            bound first in IE](http://bugs.jquery.com/ticket/7922)
+            -   dmethvin is working on this, should have a patch by the
+                end of the day.
+
+        -   [jQuery 1.4.4+ fails to load on pages with old Prototype
+            (\<= 1.5) or Current Prototype + Scriptaculous in
+            IE](http://bugs.jquery.com/ticket/8033)
+            -   SlexAxton, done – landing now.
+
+        -   [SPAN element becomes block level on
+            show()](http://bugs.jquery.com/ticket/8099)
+            -   rwaldron, done – landing now.
+
+        -   [jQuery metadata is exposed on plain JS objects when
+            serializing with
+            JSON.stringify](http://bugs.jquery.com/ticket/8108)
+            -   dmethvin is tackling now, using a toJSON override
+                approach
+            -   [https://github.com/dmethvin/jquery/commit/7acd7ae2abc04aa10fcd61ed618e1cb20f27fd2b](https://github.com/dmethvin/jquery/commit/7acd7ae2abc04aa10fcd61ed618e1cb20f27fd2b)
+
+    -   Release notes
+        -   Addy is tackling
+
+-   Timmywil is asking for review of his pulls
+    -   [https://github.com/jquery/jquery/pulls/timmywil](https://github.com/jquery/jquery/pulls/timmywil)
+
+

--- a/minutes/core/2011-02-21.md
+++ b/minutes/core/2011-02-21.md
@@ -1,0 +1,59 @@
+Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Time: Noon ET
+
+Official Agenda:
+
+AGENDA for jQuery Meeting  
+ Duration is 1 hour, so please keep comments brief and to the point to
+facilitate discussion on all topics
+
+CORE
+
+-   1.5.1 Status
+    -   RC went out last Friday, final is on Thursday
+    -   Blockers:
+        [http://bugs.jquery.com/report/75](http://bugs.jquery.com/report/75)
+        -   -   No open blockers?
+            -   Release will be built early Wed. in order to get on the
+                CDNs in time for the release.
+                -   I’ll make sure that the web site isn’t updated until
+                    the release notes are up.
+
+            -   Final release will be Thursday
+
+    -   Docs
+        -   A couple Ajax options that were added
+        -   Also a few jQuery.support updates
+        -   Will be documented by Wednesday (kswedberg is on it)
+
+    -   Release notes
+        -   Just update the existing 1.5.1 notes (addy is on it)
+
+-   Re-set date for roadmap discussion
+    -   March, 7th: Normal meeting time
+    -   Announce that date/time during the 1.5.1 release
+    -   We need to give devs at least a couple weeks to prepare
+    -   John: Needs to set up a Google Doc for people to submit to2
+
+-   IE9 support discussion
+    -   Should absolutely have official support now, as it’s in RC – we
+        can announce that with 1.5.1
+    -   A few outstanding issues:
+        -   Problem with :nth-child(-) failing (IE 9 failure)
+        -   Test for clone is insufficient, causing failures (jQuery
+            problem – Snover, rwaldron — John fixed)
+
+    -   Testing:
+        -   Install IE 9RC as default browser
+        -   Then install standalone IE 6 – 8:  
+
+            http://www.google.com/search?q=”Spoon.net\_-\_Sandboxed\_IE6\_IE7\_IE8\_Standalone”
+        -   Could possibly also use:  
+
+            [http://www.microsoft.com/downloads/en/details.aspx?FamilyID=8e6ac106-525d-45d0-84db-dccff3fae677&displaylang=en](http://www.microsoft.com/downloads/en/details.aspx?FamilyID=8e6ac106-525d-45d0-84db-dccff3fae677&displaylang=en)
+
+    -   Older notes:  
+         [http://oksoclap.com/t30I14F5LM](http://oksoclap.com/t30I14F5LM)
+
+

--- a/minutes/core/2011-02-28.md
+++ b/minutes/core/2011-02-28.md
@@ -1,0 +1,42 @@
+Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Time: Noon ET
+
+Official Agenda:
+
+-   1.5.1 Post mortem
+    -   Went well!
+
+-   1.5.2 Status
+    -   Blockers (none at the moment):  
+         [http://bugs.jquery.com/report/77](http://bugs.jquery.com/report/77)
+    -   Possible blockers:
+        -   .is(“div”) on disconnected nodes:  
+
+            [http://bugs.jquery.com/ticket/8381](http://bugs.jquery.com/ticket/8381)
+        -   Special events are not being cloned properly  
+
+            [http://bugs.jquery.com/ticket/8397](http://bugs.jquery.com/ticket/8397)
+        -   try/catch in resolveWith  
+
+            [http://bugs.jquery.com/ticket/8353](http://bugs.jquery.com/ticket/8353)
+        -   Issues with focusin/focusout  
+
+            [http://bugs.jquery.com/ticket/7340](http://bugs.jquery.com/ticket/7340)
+            -   Joern says: “The fix that was in 1.4.4 was reverted in
+                1.5.x and now breaks things in the validation plugin
+                testsuite. It seems to be mostly an issue when trying to
+                trigger focusin on the target element, but is hard to
+                pinpoint.”
+
+    -   Possible release date  
+         End of March.
+
+-   1.6 Feature Proposal Discussion
+    -   [https://spreadsheets.google.com/ccc?key=0AuWerG7Xqt-8dDcwNUlSaWltOWJrNE5tOUlIbkVJbGc&hl=en&authkey=CIjOo7UK](https://spreadsheets.google.com/ccc?key=0AuWerG7Xqt-8dDcwNUlSaWltOWJrNE5tOUlIbkVJbGc&hl=en&authkey=CIjOo7UK)
+    -   Todo: Pull in highly voted feature requests from the Tracker to
+        the spreadsheet
+    -   We’re shooting for a beta release of 1.6 mid-April (jQuery
+        Conference)
+
+

--- a/minutes/core/2011-03-07.md
+++ b/minutes/core/2011-03-07.md
@@ -1,0 +1,43 @@
+Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Time: Noon ET
+
+Official Agenda:
+
+-   1.5.2 Blocker Status
+    -   [http://bugs.jquery.com/report/205](http://bugs.jquery.com/report/205)
+    -   Open Blockers:
+        1.  [.focus() not triggering focusin event for .live binding
+            (1.4.3)?](http://bugs.jquery.com/ticket/7340) (Dave)
+        2.  [\$(‘:text’) should match \<input\> since \`type=text\` is
+            the implied default](http://bugs.jquery.com/ticket/8380)
+            (John)
+        3.  [.is(“div”) fails on disconnected elements in
+            IE9](http://bugs.jquery.com/ticket/8381) (John)
+        4.  [trigger(‘mouseover’) no longer triggers
+            mouseenter](http://bugs.jquery.com/ticket/8456) (Dave)
+        5.  Issues with focusin/focusout (Dave)  
+
+            [http://bugs.jquery.com/ticket/7340](http://bugs.jquery.com/ticket/7340)
+
+    -   Any other possible blockers?
+        1.  Special events are not being cloned properly  
+
+            [http://bugs.jquery.com/ticket/8397](http://bugs.jquery.com/ticket/8397)  
+
+            [http://bugs.jquery.com/ticket/7037](http://bugs.jquery.com/ticket/7037)
+        2.  May have to wait for 1.6
+        3.  Release Date
+            -   1.  Release on 31st
+                2.  RC on the 24th
+
+            -   1.6 Roadmap Discussion
+                -   [https://spreadsheets.google.com/ccc?key=0AuWerG7Xqt-8dDcwNUlSaWltOWJrNE5tOUlIbkVJbGc&hl=en&authkey=CIjOo7UK](https://spreadsheets.google.com/ccc?key=0AuWerG7Xqt-8dDcwNUlSaWltOWJrNE5tOUlIbkVJbGc&hl=en&authkey=CIjOo7UK)
+                -   We may need to continue collecting feedback over the
+                    next week
+                    1.  Need feedback from Jitter and SnoverDIDIT
+                    2.  Need more feedback from Dave and Julian
+
+                -   Form is closing at the END OF THE DAY
+
+

--- a/minutes/core/2011-03-14.md
+++ b/minutes/core/2011-03-14.md
@@ -1,0 +1,66 @@
+Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Time: Noon ET
+
+Official Agenda:
+
+-   1.5.2 Blocker Status
+    -   Delayed discussion until next week
+
+-   jQuery 1.6 Roadmap
+    -   [https://spreadsheets.google.com/ccc?key=0AuWerG7Xqt-8dDcwNUlSaWltOWJrNE5tOUlIbkVJbGc&hl=en&authkey=CIjOo7UK\#gid=0](https://spreadsheets.google.com/ccc?key=0AuWerG7Xqt-8dDcwNUlSaWltOWJrNE5tOUlIbkVJbGc&hl=en&authkey=CIjOo7UK#gid=0)
+    -   Be sure to land this in branches
+        1.  Will be pulled into core after 1.5.2 is out
+
+    -   A: Solid agreement, with owner or pull request:
+        1.  2 (danheberden, jaubourg): Have .animate() implement a
+            deferred object
+        2.  5 (jaubourg): Do support tests in an iframe document (or
+            maybe use false body element)
+        3.  10 (dmethvin): Optimize RegExp used for innerHTML shortcut
+            (\#6782, pull 248)
+        4.  13 (john): Add :focus to Sizzle
+        5.  14 (rwaldron): Allow properties to be passed in to
+            \$.Event() constructor
+        6.  15 (dmethvin): Perf improvements for .data() events
+        7.  16 (danheberden): Optimize validation in parseJSON
+        8.  17 (rwaldron): Fix event firing order
+        9.  20 (dmethvin): Attach data cache directly to element
+        10. 21 (dmethvin): Refactor jQuery.event.trigger/handle
+        11. 22 (dmethvin): Issue with triggering of focusin – may be
+            fixed by pull 260, need to check with Joern who reported a
+            problem i couldn’t repro
+        12. 23 (timmywil): Allow .is(), .find(), and .closest() to
+            accept nodes
+        13. 31 (lrbabe and/or gnarf and/or jaubourg): Synchronize
+            animations based upon start time (Thunderdome!)
+        14. 34 (john): attrHooks
+        15. 36 (lrbabe): Use requestAnimationFrame \*Special attention
+            to optimizing size
+        16. 38 (danheberden): \$.map() working on objects
+        17. 39 (rwaldron): .undelegate() doesn’t work on custom
+            namespaced events
+        18. 42 (timmywil): .closest() fails on disconnected nodes
+        19. 45 (john): Make .width() work correctly for inputs
+        20. 46 (john): jQuery throwing error on replaceWith
+        21. 51 (ajpiano): Support relative values for .css()
+        22. 52 (gf3, cowboy): Add Function.prototype.bind() support to
+            jQuery.proxy
+
+    -   Good, but requires more discussion for potential 1.6 inclusion:
+        1.  3 (jaubourg): Add chaining to promisHes
+        2.  7: Solution for HTML 5 in IE
+        3.  25 (timmywil): Add .valHooks
+
+    -   Tabled until 1.7:
+        1.  6: Expose the data conversion interface from \$.ajax()
+        2.  11: Comprehensive and official support of file:
+        3.  37: Use the same event object when bubbling native events,
+            or preserve data relative to the event.
+
+    -   How was the decision made:
+        1.  Virtually all green = Solid Agreement
+        2.  Majority green = Mixed agreement
+        3.  Majority red / little green = Rejected
+
+

--- a/minutes/core/2011-03-21.md
+++ b/minutes/core/2011-03-21.md
@@ -1,0 +1,64 @@
+Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Time: Noon ET
+
+Official Agenda:
+
+-   1.5.2 Blocker Status
+    -   [http://bugs.jquery.com/report/205](http://bugs.jquery.com/report/205)
+    -   RC on the 24th
+    -   Release on the 31st
+    -   Bugs:
+        1.  [\$(‘:text’) should match \<input\> since \`type=text\` is
+            the implied default](http://bugs.jquery.com/ticket/8380)
+            (john)
+        2.  [.is(“div”) fails on disconnected elements in
+            IE9](http://bugs.jquery.com/ticket/8381) (john)
+        3.  [[ firefox] jquery \>= 1.5 won’t work with flowplayer
+            tooltip](http://bugs.jquery.com/ticket/8474) (dmethvin)
+        4.  Also:
+            [http://bugs.jquery.com/ticket/8316](http://bugs.jquery.com/ticket/8316)
+
+    -   jQuery 1.6 Status
+        -   2 (danheberden, jaubourg): Have .animate() implement a
+            deferred object
+        -   5 (jaubourg): Do support tests in an iframe document (or
+            maybe use false body element)
+        -   10 (dmethvin): Optimize RegExp used for innerHTML shortcut
+            (\#6782, pull 248)
+        -   13 (john): Add :focus to Sizzle
+        -   14 (rwaldron): Allow properties to be passed in to
+            \$.Event() constructor
+        -   15 (dmethvin): Perf improvements for .data() events
+        -   16 (danheberden): Optimize validation in parseJSON
+        -   17 (rwaldron): Fix event firing order
+        -   20 (dmethvin): Attach data cache directly to element
+        -   21 (dmethvin): Refactor jQuery.event.trigger/handle
+        -   22 (dmethvin): Issue with triggering of focusin – may be
+            fixed by pull 260, need to check with Joern who reported a
+            problem i couldn’t repro
+        -   23 (timmywil): Allow .is(), .find(), and .closest() to
+            accept nodes
+            1.  A solution for find has been found, closest is coming
+                along
+
+        -   31 (jaubourg): Synchronize animations based upon start time
+            (Thunderdome!)
+        -   34 (john): attrHooks
+            1.  [http://bugs.jquery.com/ticket/3685](http://bugs.jquery.com/ticket/3685)
+                DOM0, Prehistoric document.forms API issue
+            2.  [http://oksoclap.com/attrhooks-bugs](http://oksoclap.com/attrhooks-bugs)
+
+        -   36 (lrbabe): Use requestAnimationFrame \*Special attention
+            to optimizing size
+        -   38 (danheberden): \$.map() working on objects
+        -   39 (rwaldron): .undelegate() doesn’t work on custom
+            namespaced events
+        -   42 (timmywil): .closest() fails on disconnected nodes
+        -   45 (john): Make .width() work correctly for inputs
+        -   46 (john): jQuery throwing error on replaceWith
+        -   51 (ajpiano): Support relative values for .css()
+        -   52 (gf3, cowboy): Add Function.prototype.bind() support to
+            jQuery.proxy
+
+

--- a/minutes/core/2011-03-28.md
+++ b/minutes/core/2011-03-28.md
@@ -1,0 +1,62 @@
+Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Time: Noon ET
+
+Official Agenda:
+
+-   1.5.2 Blocker Status
+    -   [http://bugs.jquery.com/report/205](http://bugs.jquery.com/report/205)
+    -   Release on the 31st
+    -   Bugs:
+        1.  [Firefox: uncaught exception at line
+            1285](http://bugs.jquery.com/ticket/8635)
+
+    -   Bug Triage on Wednesday (11am EST)
+        -   Adam, Rick, John, Ben all together in Boston, everyone else,
+            please help from your internet (Julian is helping from the
+            net)
+
+    -   jQuery 1.6 Status ( beta release of 1.6 on April 15th )
+        -   2 (danheberden, jaubourg): Have .animate() implement a
+            deferred object
+        -   5 (jaubourg): Do support tests in an iframe document (or
+            maybe use false body element)
+        -   10 (dmethvin): Optimize RegExp used for innerHTML shortcut
+            (\#6782, pull 248)
+        -   13 (john): Add :focus to Sizzle
+        -   14 (rwaldron): Allow properties to be passed in to
+            \$.Event() constructor
+        -   15 (dmethvin): Perf improvements for .data() events
+        -   16 (danheberden): Optimize validation in parseJSON
+        -   17 (rwaldron): Fix event firing order
+        -   20 (dmethvin): Attach data cache directly to element
+        -   21 (dmethvin): Refactor jQuery.event.trigger/handle
+        -   22 (dmethvin): Issue with triggering of focusin – may be
+            fixed by pull 260, need to check with Joern who reported a
+            problem i couldn’t repro
+        -   23 (timmywil): Allow .is(), .find(), and .closest() to
+            accept nodes
+            1.  Pull request is ready
+
+        -   31 (jaubourg): Synchronize animations based upon start time
+            (Thunderdome!)
+        -   34 (john): attrHooks
+            1.  [http://bugs.jquery.com/ticket/3685](http://bugs.jquery.com/ticket/3685)
+                DOM0, Prehistoric document.forms API issue
+            2.  [http://oksoclap.com/attrhooks-bugs](http://oksoclap.com/attrhooks-bugs)
+
+        -   36 (lrbabe): Use requestAnimationFrame \*Special attention
+            to optimizing size
+        -   38 (danheberden): \$.map() working on objects
+        -   39 (rwaldron): .undelegate() doesn’t work on custom
+            namespaced events
+        -   42 (timmywil): .closest() fails on disconnected nodes
+        -   45 (john): Make .width() work correctly for inputs
+        -   46 (john): jQuery throwing error on replaceWith
+        -   51 (ajpiano): Support relative values for .css()
+        -   52 (gf3, cowboy): Add Function.prototype.bind() support to
+            jQuery.proxy
+
+    -   New feature requests: will not be landed for 1.6
+
+

--- a/minutes/core/2011-04-04.md
+++ b/minutes/core/2011-04-04.md
@@ -1,0 +1,102 @@
+Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Time: Noon ET
+
+Official Agenda:
+
+-   Q&A – jswartwood & dataEvents ( someone is actually using them )
+-   Bug Triage Sprint was a big success, cleared out unreviewed tickets
+    -   Focus now is on clearing out [old open
+        tickets](http://bugs.jquery.com/query?status=assigned&status=new&status=open&status=reopened&type=bug&component=%21datalink&component=%21global&component=%21templates&component=%21web&milestone=%211.next&milestone=%211.7&milestone=%211.6&group=component&max=200&col=id&col=summary&col=milestone&col=owner&report=7&order=id)
+
+-   Should we re-consider:
+    -   valHooks (the more modest version)?
+        1.  [https://github.com/jquery/jquery/pull/295](https://github.com/jquery/jquery/pull/295)
+
+    -   Deferred.chain/Deferred.always?
+        1.  [https://github.com/jquery/jquery/commits/deferred.1.6](https://github.com/jquery/jquery/commits/deferred.1.6)
+        2.  .always seems like a wise idea to land
+        3.  [http://forum.jquery.com/topic/a-case-for-deferred-chain](http://forum.jquery.com/topic/a-case-for-deferred-chain)
+
+    -   When do we we move features into master for alpha
+        testing/release?
+    -   jQuery 1.6 Status ( beta release of 1.6 on April 15th )
+        -   2 (danheberden, jaubourg): Have .animate() implement a
+            deferred object
+            1.  works for queued animations, not for un-queued.
+
+        -   5 (jaubourg): Do support tests in an iframe document (or
+            maybe use false body element)
+        -   10 (dmethvin): Optimize RegExp used for innerHTML shortcut
+            (\#6782, pull 248) — This wants to add \<select\> to the
+            list; need to see if selectedIndex still retained when we do
+            that.
+        -   13 (john): Add :focus to Sizzle
+        -   14 (rwaldron): Allow properties to be passed in to
+            \$.Event() constructor
+            1.  [https://github.com/jquery/jquery/pull/301](https://github.com/jquery/jquery/pull/301)
+
+        -   15 (dmethvin): Perf improvements for .data() events — in
+            general, we won’t fire data events if nobody attached a
+            handler (detected by jQuery.event.global count).
+        -   16 (danheberden): Optimize validation in parseJSON
+            1.  https://github.com/jquery/jquery/pull/300
+
+        -   17 (rwaldron): Fix event firing order Turns out this is a
+            branch of \#7340, which is Dave Methvin’s
+        -   20 (dmethvin): Attach data cache directly to element — In
+            process, need to create separate list for global events.
+            Eventually  (1.7?) we will only support firing ajax\* events
+            on document and remove global events entirely.
+        -   21 (dmethvin): Refactor jQuery.event.trigger/handle — Branch
+            is passing unit tests; landed 4/6.
+        -   22 (dmethvin): Issue with triggering of focusin – may be
+            fixed by pull 260, need to check with Joern who reported a
+            problem i couldn’t repro Fixed in 1.5.2
+        -   23 (timmywil): Allow .is(), .find(), and .closest() to
+            accept nodes
+            1.  [https://github.com/jquery/jquery/pull/206](https://github.com/jquery/jquery/pull/206)
+            2.  https://github.com/jquery/jquery/pull/283
+
+        -   31 (jaubourg): Synchronize animations based upon start time
+            (Thunderdome!)
+            1.  https://github.com/jquery/jquery/tree/synchro-anim.1.6
+
+        -   34 (john): attrHooks
+            1.  [http://bugs.jquery.com/ticket/3685](http://bugs.jquery.com/ticket/3685)
+                DOM0, Prehistoric document.forms API issue
+            2.  [http://oksoclap.com/attrhooks-bugs](http://oksoclap.com/attrhooks-bugs)
+
+        -   36 (lrbabe, timmywill): Use requestAnimationFrame \*Special
+            attention to optimizing size
+            1.  https://github.com/jquery/jquery/pull/216 original
+            2.  [https://github.com/jquery/jquery/pull/298](https://github.com/jquery/jquery/pull/298)timmywill
+                revisions
+
+        -   38 (danheberden): \$.map() working on objects
+            1.  seems pretty close to ready according to dan
+            2.  https://github.com/jquery/jquery/pull/299
+
+        -   39 (rwaldron): .undelegate() doesn’t work on custom
+            namespaced events
+        -   42 (timmywil): .closest() fails on disconnected nodes
+            1.  https://github.com/jquery/jquery/pull/291
+
+        -   45 (john): Make .width() work correctly for inputs
+        -   46 (john): jQuery throwing error on replaceWith
+        -   51 (danheberden): Support relative values for .css()
+            1.  [https://github.com/jquery/jquery/pull/78](https://github.com/jquery/jquery/pull/78)
+                original
+            2.  We wanted to see this patch DRY’ed out a bit, but we
+                discussed in meeting and determined that it would
+                probably introduce overhead to share this code between
+                modules, and it’s not that much repeated code.
+                 consensus was in favour of landing as-is. Dan is going
+                to clean up the code a bit more.
+            3.  [https://github.com/jquery/jquery/pull/297](https://github.com/jquery/jquery/pull/297)
+
+            -   -   52 (gf3, cowboy): Add Function.prototype.bind()
+                    support to jQuery.proxy
+                    1.  [https://github.com/jquery/jquery/pull/133](https://github.com/jquery/jquery/pull/133)
+
+

--- a/minutes/core/2011-04-11.md
+++ b/minutes/core/2011-04-11.md
@@ -1,0 +1,149 @@
+Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Time: Noon ET
+
+Official Agenda:
+
+-   1.6pre!!! http://bit.ly/hBxZyG
+-   Timeline
+    -   beta release of 1.6 on April 15th
+
+-   Last chance to get some bugs fixed for 1.6beta ( [old open
+    tickets](http://bugs.jquery.com/query?status=assigned&status=new&status=open&status=reopened&type=bug&component=%21datalink&component=%21global&component=%21templates&component=%21web&milestone=%211.next&milestone=%211.7&milestone=%211.6&group=component&max=200&col=id&col=summary&col=milestone&col=owner&report=7&order=id)
+    )
+-   API changes
+    -   .chain has been renamed to .pipe to link deferreds
+
+-   Done and merged into master
+    -   2 (danheberden, jaubourg): Have .animate() implement a deferred
+        object
+        1.  bulk of implementation committed.
+        2.  STILL PENDING waiting on commits for un-queued animations
+
+    -   5 (jaubourg): Do support tests in an iframe document (or maybe
+        use false body element)
+    -   13 (john): Add :focus to Sizzle
+        1.  [http://bugs.jquery.com/ticket/8105](http://bugs.jquery.com/ticket/8105)
+
+    -   14 (rwaldron): Allow properties to be passed in to \$.Event()
+        constructor
+        1.  [https://github.com/jquery/jquery/pull/301](https://github.com/jquery/jquery/pull/301)
+
+    -   15 (dmethvin): Perf improvements for .data() events — in
+        general, we won’t fire data events if nobody attached a handler
+        (detected by jQuery.event.global count).
+        1.  [http://bugs.jquery.com/ticket/8790](http://bugs.jquery.com/ticket/8790)
+        2.  Need a review … I would prefer to “blacklist” natural events
+            (click, mouseover, etc) so customs would all be faster, but
+            it’s a long list:
+            [https://github.com/dmethvin/jquery/tree/fix-8790-quick-trigger](https://github.com/dmethvin/jquery/tree/fix-8790-quick-trigger)
+            -   John: Can you do a pull request for this so that the
+                diff is easier to see?
+
+        3.  Someone that uses dataEvents:
+        4.  [https://github.com/jswartwood/jQuery-dataDefer](https://github.com/jswartwood/jQuery-dataDefer)
+
+    -   16 (danheberden): Optimize validation in parseJSON
+        1.  [https://github.com/jquery/jquery/pull/300](https://github.com/jquery/jquery/pull/300)
+
+    -   17 (rwaldron): Fix event firing order Turns out this is a branch
+        of \#7340, which is Dave Methvin’s
+    -   21 (dmethvin): Refactor jQuery.event.trigger/handle — Branch is
+        passing unit tests; landed 4/6.
+        1.  [http://jsperf.com/jq152-vs-jq16pre-trigger/3](http://jsperf.com/jq152-vs-jq16pre-trigger/3)
+
+    -   22 (dmethvin): Issue with triggering of focusin – may be fixed
+        by pull 260, need to check with Joern who reported a problem i
+        couldn’t repro Fixed in 1.5.2
+    -   23 (timmywil): Allow .is(), .find(), and .closest() to accept
+        nodes
+        1.  [https://github.com/jquery/jquery/pull/206](https://github.com/jquery/jquery/pull/206)
+        2.  [https://github.com/jquery/jquery/pull/283](https://github.com/jquery/jquery/pull/283)
+
+    -   31 (jaubourg): Synchronize animations based upon start time
+        (Thunderdome!)
+        1.  [https://github.com/jquery/jquery/tree/synchro-anim.1.6](https://github.com/jquery/jquery/tree/synchro-anim.1.6)
+
+    -   34 (timmywil, john): attrHooks
+        1.  [https://github.com/jquery/jquery/pull/296](https://github.com/jquery/jquery/pull/296)
+            -   note this is going into the attrhooks.1.6 branch
+
+        2.  [http://bugs.jquery.com/ticket/3685](http://bugs.jquery.com/ticket/3685)
+            DOM0, Prehistoric document.forms API issue
+        3.  [http://oksoclap.com/attrhooks-bugs](http://oksoclap.com/attrhooks-bugs)
+        4.  [http://jsperf.com/attr-vs-attrhooks](http://jsperf.com/attr-vs-attrhooks)
+
+    -   36 (lrbabe, timmywill): Use requestAnimationFrame \*Special
+        attention to optimizing size
+        1.  [https://github.com/jquery/jquery/pull/216](https://github.com/jquery/jquery/pull/216)
+            original
+        2.  [https://github.com/jquery/jquery/pull/298](https://github.com/jquery/jquery/pull/298)timmywill
+            revisions
+            -   John reviewed: needs minor tweak
+
+-   38 (danheberden): \$.map() working on objects
+    1.  [https://github.com/jquery/jquery/pull/299](https://github.com/jquery/jquery/pull/299)
+
+-   39 (rwaldron): .undelegate() doesn’t work on custom namespaced
+    events
+    1.  [http://bugs.jquery.com/ticket/8777](http://bugs.jquery.com/ticket/8777)
+    2.  [https://github.com/rwldrn/jquery/tree/8777](https://github.com/rwldrn/jquery/tree/8777)
+    3.  [https://github.com/jquery/jquery/pull/302](https://github.com/jquery/jquery/pull/302)
+        -   John: Looks ok to me, landing.
+
+42 (timmywil): .closest() fails on disconnected nodes
+
+1.  [https://github.com/jquery/jquery/pull/291](https://github.com/jquery/jquery/pull/291)
+
+46 (john): jQuery throwing error on replaceWith
+
+52 (gf3, cowboy): Add Function.prototype.bind() support to jQuery.proxy
+
+1.  [https://github.com/jquery/jquery/pull/133](https://github.com/jquery/jquery/pull/133)
+
+51 (danheberden): Support relative values for .css()
+
+1.  [https://github.com/jquery/jquery/pull/78](https://github.com/jquery/jquery/pull/78)
+    original
+2.  We wanted to see this patch DRY’ed out a bit, but we discussed in
+    meeting and determined that it would probably introduce overhead to
+    share this code between modules, and it’s not that much repeated
+    code.  consensus was in favour of landing as-is. Dan is going to
+    clean up the code a bit more.
+3.  [https://github.com/jquery/jquery/pull/297](https://github.com/jquery/jquery/pull/297)
+
+valHooks (the more modest version)?
+
+1.  [https://github.com/jquery/jquery/pull/295](https://github.com/jquery/jquery/pull/295)
+    -   John: Looks good to me!
+
+2.  [http://jsperf.com/jq152-vs-jq16pre-trigger/3](http://jsperf.com/jq152-vs-jq16pre-trigger/3)
+
+Bumped to 1.6.x / 1.7
+
+-   10 (dmethvin): Optimize RegExp used for innerHTML shortcut (\#6782,
+    pull 248)
+    1.  This wants to add \<select\> to the list; need to see if
+        selectedIndex still retained when we do that.
+    2.  [https://github.com/jquery/jquery/pull/248](https://github.com/jquery/jquery/pull/248)
+    3.  [http://bugs.jquery.com/ticket/6782](http://bugs.jquery.com/ticket/6782)
+        -   Needs more testing, bumping to a 1.6.x release.
+
+20 (dmethvin): Attach data cache directly to element — In process, need
+to create separate list for global events.
+
+1.  Eventually  (1.7?) we will only support firing ajax\* events on
+    document and remove global events entirely.
+2.  [http://bugs.jquery.com/ticket/8792](http://bugs.jquery.com/ticket/8792)
+
+45 (jboesch, reviewed by john): Make .width() work correctly for inputs
+
+1.  [http://bugs.jquery.com/ticket/4146](http://bugs.jquery.com/ticket/4146)
+2.  [https://github.com/jquery/jquery/pull/253](https://github.com/jquery/jquery/pull/253)
+    -   John reviewed: Needs formatting fixes and possibly a code fix
+
+3.  also fixes
+    [http://bugs.jquery.com/ticket/3333](http://bugs.jquery.com/ticket/3333)
+    ?
+
+Check it out: [http://twitter.com/jqcommit](http://twitter.com/jqcommit)

--- a/minutes/core/2011-04-20.md
+++ b/minutes/core/2011-04-20.md
@@ -1,0 +1,94 @@
+Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Time: 2pm ET  
+ NOTE: This meeting has been moved to Wednesday to avoid conflicts with
+the jQuery Conference.
+
+Official Agenda:
+
+-   jQuery 1.6 RC
+    -   Problems with the beta?
+    -   Docs status
+    -   Blocker Status
+        -   [http://bugs.jquery.com/query?status=!closed&milestone=\^1.6&report=207&order=priority](about:blank)
+        -   [Duplicate mouseover and mouseout events added to cloned
+            element.](http://bugs.jquery.com/ticket/7037)
+        -   [Setting checked to true on a disconnected checkbox does not
+            carry over after attaching to
+            DOM.](http://bugs.jquery.com/ticket/8060)
+        -   [live(“hover”, … ) broken in
+            1.5.1](http://bugs.jquery.com/ticket/8543)
+        -   [Leak with events in IE](http://bugs.jquery.com/ticket/8545)
+
+    -   Release Dates:
+        -   RC: Tuesday the 26th
+        -   Final: Tuesday the 3rd
+
+-   1.7 spreadsheet will be available with 1.6 release
+
+-   Pull Request Review
+    -   [Fix 6782 – Optimize regex for innerHTML to allow more html
+        snippets to use faster
+        method](https://github.com/jquery/jquery/pull/248)
+        -   Patch appears to be in limbo? Dave, do you have this one?
+        -   [http://bugs.jquery.com/ticket/6782](http://bugs.jquery.com/ticket/6782)
+
+    -   [Fix for bug 6593](https://github.com/jquery/jquery/pull/156)
+        -   John: Needs some tests and code cleanup
+        -   [http://bugs.jquery.com/ticket/6593](http://bugs.jquery.com/ticket/6593)
+
+    -   [\#7061 – In IE form isn’t submitted when disabling submit
+        button in submit
+        callback](https://github.com/jquery/jquery/pull/104)
+        -   John: Seems like this might do the trick? Recommending a
+            possible code reorg.
+        -   [http://bugs.jquery.com/ticket/7061](http://bugs.jquery.com/ticket/7061)
+
+-   Possible 1.7 Pull Requests
+    -   Synchronous[slots](https://github.com/jquery/jquery/pull/271)
+        -   Is this a 1.7 thing? Is this needed with the recent effects
+            changes?
+        -   [http://bugs.jquery.com/ticket/6281](http://bugs.jquery.com/ticket/6281)
+
+    -   [Ticket \#8498: Animating margin/padding can cause flashes when
+        margins are set using
+        left/right/top/bottom](https://github.com/jquery/jquery/pull/267)
+        -   Sounds like this should be converted into a “CSS shorthand”
+            thing used by both .css() and .animate(). Push to 1.7?
+        -   [http://bugs.jquery.com/ticket/8498](http://bugs.jquery.com/ticket/8498)
+
+    -   [Bug 4446 – Add selector support to
+        .andSelf()](https://github.com/jquery/jquery/pull/203)
+        -   Push to 1.7?
+        -   [http://bugs.jquery.com/ticket/4446](http://bugs.jquery.com/ticket/4446)
+
+    -   [\#5479 – Allow passing multiple attributes to
+        removeAttr](https://github.com/jquery/jquery/pull/114)
+        -   Push to 1.7?
+        -   [http://bugs.jquery.com/ticket/5479](http://bugs.jquery.com/ticket/5479)
+
+    -   [\#7323 – Allow removing multiple data keys at once with
+        \$.fn.removeData](https://github.com/jquery/jquery/pull/77)
+        -   Push to 1.7?
+        -   [http://bugs.jquery.com/ticket/7323](http://bugs.jquery.com/ticket/7323)
+
+    -   [Add support for registering jQuery as an AMD
+        module](https://github.com/jquery/jquery/pull/331)
+        -   [http://bugs.jquery.com/ticket/7102](http://bugs.jquery.com/ticket/7102)
+
+<!-- -->
+
+
+    Best way to merge Pull Requests?
+
+    jQuery commit commands
+
+    git checkout master
+    git checkout -b bug1234
+    git pull http://url/to/otherrepo branchname
+    git checkout master
+    git merge --no-commit --squash bug1234
+    git commit -a --author="Original Author <author@email.example>"
+
+    To get the author:
+    git log | grep "Author" | head -1

--- a/minutes/core/2011-04-25.md
+++ b/minutes/core/2011-04-25.md
@@ -1,0 +1,29 @@
+Minutes (Notes) of the meeting of jQuery
+
+Location: \#jquery-meeting on Freenode
+
+Time: Noon ET
+
+Official Agenda:
+
+-   jQuery 1.6 RC
+    -   Docs status
+    -   Blocker Status
+        -   [http://bugs.jquery.com/report/207](http://bugs.jquery.com/report/207)
+        -   [Duplicate mouseover and mouseout events added to cloned
+            element.](http://bugs.jquery.com/ticket/7037) — still
+            working on this one, seems to have been around a while
+            -   Bumping to 1.7
+
+    -   Release Dates:
+        -   RC: Tuesday the 26th
+        -   Final: Tuesday the 3rd
+
+-   Coverage analysis of jQuery documentation:
+    -   [http://test.learningjquery.com/jquery-methods.html](http://test.learningjquery.com/jquery-methods.html)
+
+-   Merging Pull Requests
+    -   [http://ejohn.org/blog/pulley/](http://ejohn.org/blog/pulley/)
+    -   [https://github.com/blog/843-the-merge-button](https://github.com/blog/843-the-merge-button)
+
+

--- a/minutes/core/2011-05-02.md
+++ b/minutes/core/2011-05-02.md
@@ -1,0 +1,64 @@
+Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Time: Noon ET
+
+Official Agenda:
+
+-   jQuery 1.6 Status
+    -   Docs status
+        -   Good shape, .pipe() is left as are some of the hooks
+
+    -   Blog Post
+        -   Features
+            -   Attribute and Val Rewrite
+                -   Hooks
+                -   Performance Improvements
+                -   Property Methods
+                    -   .prop(), .removeProp() (Dave has this)
+
+            -   .find(), .closest() , and .is()with DOM elements and
+                jQuery objects
+            -   .css() relative values
+            -   :focus selector
+            -   Synced Animations
+                -   Also: requestAnimationFrame
+
+            -   Using Function.prototype.bind
+            -   jQuery.map object
+            -   Deferreds (Julian has this)
+                -   .promise()
+                -   deferred.always()
+                -   deferred.pipe()
+
+            -   Breaking Changes
+                -   Should this be integrated into the attribute
+                    section?
+                -   (Dave has this) —\> My text:
+                -   [https://docs.google.com/document/d/1Oit\_IX1xZg7wRcmpPPrtoqv6wIbnlJB9YBxn-EnZOxE/edit?hl=en&authkey=CMmB-rMP\#](https://docs.google.com/document/d/1Oit_IX1xZg7wRcmpPPrtoqv6wIbnlJB9YBxn-EnZOxE/edit?hl=en&authkey=CMmB-rMP#)
+
+        -   Performance Improvements
+            -   .attr(“get”) and .attr(“name, “set”)
+                -   [http://jsperf.com/attr-vs-attrhooks](http://jsperf.com/attr-vs-attrhooks)
+
+            -   .val(“get”)
+                -   [http://jsperf.com/valhooks-vs-val/2](http://jsperf.com/valhooks-vs-val/2)
+
+            -   .data() / .trigger()
+                -   [http://jsperf.com/jq152-vs-jq16pre-trigger/3](http://jsperf.com/jq152-vs-jq16pre-trigger/3)
+
+        -   Accepting Feature Requests for 1.7
+            -   [https://spreadsheets.google.com/viewform?hl=en&authkey=CPmgicsO&formkey=dG0yTEs2ZTFWQUhDRUp5dzRyc3NwV2c6MA\#gid=0](https://spreadsheets.google.com/viewform?hl=en&authkey=CPmgicsO&formkey=dG0yTEs2ZTFWQUhDRUp5dzRyc3NwV2c6MA#gid=0)
+
+    -   Blocker Status
+        -   [http://bugs.jquery.com/report/207](http://bugs.jquery.com/report/207)
+            -   [jQuery doesn’t parse html from string
+                correctly!](http://bugs.jquery.com/ticket/8984)
+                -   John: Fixed
+
+    -   Release Dates:
+        -   Final: Tuesday the 3rd
+
+-   Coverage analysis of jQuery documentation:
+    -   [http://test.learningjquery.com/jquery-methods.html](http://test.learningjquery.com/jquery-methods.html)
+
+

--- a/minutes/core/2011-05-10.md
+++ b/minutes/core/2011-05-10.md
@@ -1,0 +1,43 @@
+Minutes (Notes) of the meeting of jQuery
+
+Location: \#jquery-meeting on Freenode
+
+Time: Noon ET  
+
+Official Agenda:   
+
+jQuery 1.6.1 Status
+
+Blocker Status:
+[http://bugs.jquery.com/query?status=!closed&milestone=\^1.6.1&order=priority](about:blank)
+
+[Unhandled exception: document.defaultView.getComputedStyle(div, null)
+is null (FF, hidden iframe)](http://bugs.jquery.com/ticket/8763)
+
+-   [https://github.com/jquery/jquery/pull/370](https://github.com/jquery/jquery/pull/370)
+-   Julian will add some tests
+
+[when hover over a child of an element, mouseleave fires when using live
+or delegate](http://bugs.jquery.com/ticket/9069)
+
+-   John fixed this.
+
+[Order of hide() callbacks has
+changed](http://bugs.jquery.com/ticket/9100)
+
+-   [https://github.com/jquery/jquery/pull/374](https://github.com/jquery/jquery/pull/374)
+
+[Changes to \$.data illogical in certain
+case](http://bugs.jquery.com/ticket/9124)
+
+-   John fixed this.
+
+[:reset pseudo-selector broken](http://bugs.jquery.com/ticket/9154)
+
+-   John: I got this.
+
+Release Dates:
+
+-   RC on Tuesday the 10th
+-   Final on Thursday the 12th
+

--- a/minutes/core/2011-05-16.md
+++ b/minutes/core/2011-05-16.md
@@ -1,0 +1,26 @@
+Minutes (Notes) of the meeting of jQuery
+
+Location: \#jquery-meeting on Freenode
+
+Time: Noon ET  
+
+Official Agenda:   
+
+jQuery 1.6.2 Status
+
+[http://bugs.jquery.com/query?status=!closed&milestone=\^1.6.2&order=priority](http://bugs.jquery.com/query?status=%21closed&milestone=%5E1.6.2&order=priority)
+
+Blockers
+
+-   [outerWidth()](http://bugs.jquery.com/ticket/7557)
+
+No major rush, just keep fixing bugs. We’ll set a date soon (likely in a
+month or so)
+
+jQuery 1.7 Roadmap
+
+-   [https://spreadsheets.google.com/ccc?key=0AuWerG7Xqt-8dG0yTEs2ZTFWQUhDRUp5dzRyc3NwV2c&authkey=CPmgicsO&hl=en\#gid=0](https://spreadsheets.google.com/ccc?key=0AuWerG7Xqt-8dG0yTEs2ZTFWQUhDRUp5dzRyc3NwV2c&authkey=CPmgicsO&hl=en#gid=0)
+-   Form will close in a week
+-   Don’t vote on stuff now, will move to bug tracker
+-   Currently looking towards an October release
+

--- a/minutes/core/2011-05-23.md
+++ b/minutes/core/2011-05-23.md
@@ -1,0 +1,57 @@
+Minutes (Notes) of the meeting of jQuery
+
+Location: \#jquery-meeting on Freenode
+
+Time: Noon ET  
+
+Official Agenda:   
+
+jQuery 1.6.2 Status
+
+[http://bugs.jquery.com/query?status=!closed&milestone=\^1.6.2&order=priority](about:blank)
+
+Blockers
+
+-   [outerWidth()](http://bugs.jquery.com/ticket/7557)
+
+No major rush, just keep fixing bugs. We’ll set a date soon (likely in a
+month or so)
+
+jQuery 1.7 Roadmap
+
+[http://bugs.jquery.com/report/501](http://bugs.jquery.com/report/501)
+
+Voting on Bugs:
+
+-   The  
+     point of voting on the blockers is that they're, previously
+    nominated  
+     by just one person as being a blocker – we use this opportunity
+    to  
+     determine if it should remain a blocker (and be fixed) or if not,
+    get  
+     bumped down to a lower priority.
+
+Voting on Features:
+
+-   In the case of feature/enhancement requests – either land it or
+    close the bug as wontfix
+
+Form is now closed
+
+Team members should have permission to vote, please let John know if you
+don’t have access, for some reason.
+
+Voting should be done by June 6th
+
+-   Roadmap Meeting on June 6th
+
+Final Release: September 30th
+
+Beta 1: September 1st
+
+Alpha 1: August 1st
+
+September will be dedicated towards Q&A
+
+August will be dedicated towards docs writing

--- a/minutes/core/2011-06-03.md
+++ b/minutes/core/2011-06-03.md
@@ -1,0 +1,3 @@
+No updates from the core team this week – meeting wasn't held due to
+conflict with Memorial Day in the US. Work is continuing on 1.6.2 and
+votes are still being tallied for the 1.7 roadmap meeting.

--- a/minutes/core/2011-06-06.md
+++ b/minutes/core/2011-06-06.md
@@ -1,0 +1,29 @@
+Minutes (Notes) of the meeting of jQuery
+
+Location: \#jquery-meeting on Freenode
+
+Time: Noon ET  
+
+Official Agenda:   
+
+Collaboration with Google Closure Compiler
+
+-   Chad Killinsworth (non-Google contributor) and Alan Leung (at
+    Google) to join today’s meeting
+-   goal:  
+     demonstrate mutual interest, thereby making better support of
+    jQuery in  
+     advanced mode a priority for the Closure Compiler team
+
+jQuery 1.6.2 Status
+
+-   Keep on keepin’ on.
+
+jQuery 1.7 Roadmap
+
+[http://bugs.jquery.com/report/501](http://bugs.jquery.com/report/501)
+
+Voting Results:
+
+-   [https://spreadsheets.google.com/spreadsheet/pub?hl=en&key=0AuWerG7Xqt-8dG0yTEs2ZTFWQUhDRUp5dzRyc3NwV2c&hl=en&gid=2](https://spreadsheets.google.com/spreadsheet/pub?hl=en&key=0AuWerG7Xqt-8dG0yTEs2ZTFWQUhDRUp5dzRyc3NwV2c&hl=en&gid=2)
+

--- a/minutes/core/2011-06-13.md
+++ b/minutes/core/2011-06-13.md
@@ -1,0 +1,23 @@
+Minutes (Notes) of the meeting of jQuery
+
+Location: \#jquery-meeting on Freenode
+
+Time: Noon ET  
+
+Official Agenda:   
+
+jQuery 1.6.2 Status
+
+-   We're getting the RC out today.
+
+Talked with Closure Compiler team, they’re fixing bugs, should be good
+for the team
+
+We’re working on dates for an upcoming bug triage day, possibly late
+June
+
+Firefox version support moving forward
+
+-   Mozilla has dropped support for 3.0 and 3.5, makes sense for us to
+    do the same
+

--- a/minutes/core/2011-06-21.md
+++ b/minutes/core/2011-06-21.md
@@ -1,0 +1,25 @@
+Minutes (Notes) of the meeting of jQuery
+
+Location: \#jquery-meeting on Freenode
+
+Time: Noon ET
+
+Official Agenda:
+
+jQuery 1.6.2 status
+
+-   RC1 has had some bug closed and \$.browser.chrome ready to pull,
+    should we do an RC2?
+-   DaveMethvin: it seems like 1.6.2 may be in good shape then? other
+    than a peaceful queasy feeling?
+-   Seems to be a no on RC2, pending John and Timmy’s input
+
+Bug Triage Day: July 11th and 12th – Same day as ARIA Hackathon (
+[http://wiki.jqueryui.com/ARIA-Hackathon](http://wiki.jqueryui.com/ARIA-Hackathon)
+), but no real overlap of people.  Could be useful to know UI team is at
+least available for questions.
+
+-   July 11th – all day
+-   July 12th – till 2:30pm
+-   Project to vote on airfare for Timmy -\> BOS
+

--- a/minutes/core/2011-06-28.md
+++ b/minutes/core/2011-06-28.md
@@ -1,0 +1,16 @@
+Minutes (Notes) of the meeting of jQuery
+
+Location: \#jquery-meeting on Freenode
+
+Time: Noon ET  
+
+Official Agenda:   
+
+jQuery 1.6.2 status
+
+-   Get the release out today or tomorrow.
+
+Bug Triage Day: July 11th and 12th
+
+-   Holding vote now for travel budget approval.
+

--- a/minutes/core/2011-11-01.md
+++ b/minutes/core/2011-11-01.md
@@ -1,0 +1,28 @@
+October 31, Noon ET
+
+-   jQuery 1.7 Release
+    -   Open tix – [http://goo.gl/d0nPr](http://goo.gl/d0nPr)
+    -   Detached head IE8 crash (Halloween bug) blocker
+        -   [http://bugs.jquery.com/ticket/10613](http://bugs.jquery.com/ticket/10613)
+
+    -   .show() regression?
+        -   [http://bugs.jquery.com/ticket/10622](http://bugs.jquery.com/ticket/10622)
+
+    -   timmywil to rename jQuery.support.supportsFixedPosition
+    -   Do these fixes reopen any old bugs?
+    -   RC2 this afternoon?
+    -   Release on Thursday? (need to ensure we fixed this bug!)
+    -   DOCUMENTATION by 11/3 before we release
+        -   [http://oksoclap.com/1-7-docs](http://oksoclap.com/1-7-docs)
+        -   event property hooks — may come after release?
+        -   deferred.state() — done, pending review (get it?)
+            -   replaces isResolved, isRejected, etc booleans –dave
+
+        -   \$.Callbacks — addy will write
+            -   [http://addyosmani.com/blog/jquery-1-7s-callbacks-feature-demystified/](http://addyosmani.com/blog/jquery-1-7s-callbacks-feature-demystified/)
+
+        -   animate queues — hooks object. leave undocumented for now.
+        -   AMD –mention in the blog post for now
+            -   [https://github.com/jquery/jquery/commit/bba3d610c7e3b611fe1eb89178c91106a156a5d](https://github.com/jquery/jquery/commit/bba3d610c7e3b611fe1eb89178c91106a156a5dc)
+
+ 

--- a/minutes/core/2011-11-14.md
+++ b/minutes/core/2011-11-14.md
@@ -1,0 +1,34 @@
+November 14, 2011  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Time: Noon ET 
+
+Official Agenda:
+
+-   jQuery 1.7.1 Issues
+    -   Rework support.js, reduce startup time
+    -   [http://bugs.jquery.com/query?milestone=1.7.1&col=id&col=summary&col=owner&col=status&order=status](http://bugs.jquery.com/query?milestone=1.7.1&col=id&col=summary&col=owner&col=status&order=status)
+    -   Land fixes for unit tests so we aren’t STILL FAILING — DONE!
+        (Dave)
+    -   1.7.1 RC Tuesday, final shoot for Friday?
+
+-   Pull request process
+    -   Help is welcome but some PRs are more work than their value
+    -   How should we approach those? Leaving in the queue means they go
+        stale
+    -   Ask ppl to engage us before making a PR?
+    -   Review current open PRs:
+        [https://github.com/jquery/jquery/pulls](https://github.com/jquery/jquery/pulls)
+
+-   Deprecation blog post feedback (Dave)
+    -   Followup blog post to address suggestions in blog comments
+        -   “Remove all IE support!”
+        -   “Break it into tiny little parts and have a download
+            builder!”
+        -   “Wait until 2.0 to remove stuff”
+        -   “Make effects and/or ajax optional”
+
+    -   Need a a review to ensure we have marked deprecated in API docs
+        (Dave)
+
+ 

--- a/minutes/core/2011-12-13.md
+++ b/minutes/core/2011-12-13.md
@@ -1,0 +1,20 @@
+December 12, 2011  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Time: Noon ET
+
+Official Agenda:
+
+-   Open bugs — jQuery 1.7.2? [http://goo.gl/jYbsc](http://goo.gl/jYbsc)
+-   1.8 voting in tracker — [http://goo.gl/sy3Ax](http://goo.gl/sy3Ax)
+    -   Suggestions boiled from list (see link from last week)
+    -   Team voting on 1.8 suggestions this week; Team vote here:
+        [http://goo.gl/lhKlz](http://goo.gl/lhKlz)
+    -   Don’t add bugs to here unless you need to discuss them by vote
+    -   Landing contingent on final code review (size especially)
+
+-   Public link to suggestions spreadsheet (sans emails):
+    [http://goo.gl/9Ss0K](http://goo.gl/9Ss0K)
+-   Closure Compiler status — Chad working on string-defined methods
+
+ 

--- a/minutes/core/2012-04-03.md
+++ b/minutes/core/2012-04-03.md
@@ -1,0 +1,56 @@
+April 2, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: dmethvin, timmywil, mikesherov, gnarf  
+ Time: Noon ET
+
+Official Agenda:  
+
+1.7.2
+
+New issues?
+
+Bad TinyMCE .attr() duck punch seems to be resolved by their beta
+
+-   need to land
+    [https://github.com/jquery/jquery/pull/720](https://github.com/jquery/jquery/pull/720)
+    ? (no, close)
+-   Thanks mikesherov and rwaldron
+
+Bug tracker misbehavin’ again last week
+
+-   Who knows why, but a reboot fixed it…
+
+Style guide: Did we remove the ambiguous “space around quotes” rule?
+
+-   Dave to create epic email thread regarding this
+
+[http://bugs.jquery.com/ticket/11539](http://bugs.jquery.com/ticket/11539)
+Do we want to change our support for text nodes?
+
+-   gibson042: traversing is safe for text nodes, manipulation is not?
+
+Triage
+
+-   [http://goo.gl/fbZD3](http://goo.gl/fbZD3)
+-   Dave to coordinate a meeting time this week if possible
+
+1.8 (April 9 Beta)
+
+Dev on master or branch? Consensus: 1.8 on Development Branch
+
+1.8 Feature branch — we’ll land PRs there?
+
+Specific process?
+
+-   Make standard PRs but against 1.8 branch (after I create it)
+-   [https://github.com/jquery/jquery/branches](https://github.com/jquery/jquery/branches)
+-   Um, create 1.8 branch (BRANCH is 1.8pre b/c there was 1.8 subs?)
+-   WHY CAN’T I label PRs? (gnarf: maybe bc issues are off?)
+
+Several PRs ready to land
+
+jaubourg has been a good boy
+
+Pinged Chad Killingsworth re Closure Compiler, he made a Sizzle PR for
+some issues to simplify CC work (haven’t reviewed it yet)

--- a/minutes/core/2012-04-09.md
+++ b/minutes/core/2012-04-09.md
@@ -1,0 +1,36 @@
+April 9, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: dmethvin, gibson042, timmywil, gnarf, ajpiano, rwaldron  
+ Time: Noon ET
+
+Official Agenda:  
+
+Triage
+
+-   [http://goo.gl/fbZD3](http://goo.gl/fbZD3)
+-   Meeting? Or can we do comments on the tickets to resolve?
+
+1.8 (April 9 Beta)
+
+Landed many PRs on 1.8pre branch last week
+
+-   [https://github.com/jquery/jquery/tree/1.8pre](https://github.com/jquery/jquery/tree/1.8pre)
+
+garf’s opus on animations
+
+-   [https://github.com/jquery/jquery/pull/731](https://github.com/jquery/jquery/pull/731)
+-   Team review, need to make it smaller
+
+Chad Killingsworth’s CCAO changes
+
+-   [https://github.com/dmethvin/jquery/tree/ccao](https://github.com/dmethvin/jquery/tree/ccao)
+-   needs TLC on its build stuff for grunt
+-   (General concern about size/complexity/maintenance)
+-   Waiting to land for another week for further discussion
+
+What else needs to land?
+
+-   timmywil to get Sizzle changes next weekend
+-   build process using grunt
+

--- a/minutes/core/2012-04-16.md
+++ b/minutes/core/2012-04-16.md
@@ -1,0 +1,61 @@
+April 16, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, sindresorhus, mikesherov, ajpiano, gnarf,
+gibson042, fleeting appearance by timmywil  
+ Time: Noon ET
+
+Official Agenda:  
+
+rwaldron has commit privs on github.com/jquery
+
+-   Congrats!
+-   Hide yo kids
+-   Hide yo wife
+
+Triage
+
+-   [http://goo.gl/fbZD3](http://goo.gl/fbZD3)
+-   Meeting on Wednesday noon?
+
+1.8
+
+gnarf’s opus on animations
+
+-   [https://github.com/jquery/jquery/pull/731](https://github.com/jquery/jquery/pull/731)
+-   gibson042 kicked lotsa bytes out
+-   Need performance and memory leak sanity check
+-   Land this week? Still \~+200
+
+Refactor to allow leaving animation/ajax/(others?) out
+
+-   Yehuda eliminated an ajax dependency in unit tests
+-   More work to do there
+
+Land the grunt pull?
+
+-   mikesherov and DaveMethvin to figure out Windows issues
+
+Chad Killingsworth’s CCAO changes
+
+[https://github.com/dmethvin/jquery/tree/ccao](https://github.com/dmethvin/jquery/tree/ccao)
+
+needs TLC on its build stuff for grunt
+
+Proposed plan of action:
+
+-   Leave on a branch for 1.8
+-   Get unit tests and basic examples working
+-   Call for community input and help
+-   Further 1.9 integration contingent on that
+
+What else needs to land?
+
+-   timmywil to get Sizzle changes
+
+jQuery.quickReady
+
+-   Can we just always ignore state of iframes?
+-   can’t use window.load since it fires once
+-   perhaps flip the default state to allow for faster loading?
+

--- a/minutes/core/2012-04-23.md
+++ b/minutes/core/2012-04-23.md
@@ -1,0 +1,60 @@
+April 23, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, rwaldron, timmywil, gibson042, sindresorhus,
+gnarf, jaubourg  
+ Time: Noon ET
+
+Official Agenda:  
+
+new team member – gibson042
+
+Triage
+
+-   [http://goo.gl/fbZD3](http://goo.gl/fbZD3)
+-   Need a sweep of bugs and assign to 1.8
+-   Please look at tickets related to rewrites if you’re doing one
+-   Dave will ping people on specific tickets if needed
+
+1.8
+
+Beta schedule?
+
+-   Need solid final release by end of June
+-   Work backwards from there
+-   Beta?
+-   RC? Want a month given the changes
+
+Unit tests need to work better – Dave will ping jzaefferer
+
+Ready to land animations?
+
+CCAO – can we land the Sizzle CCAO changes as-is? (Timmy says yes)
+
+-   mostly quoting of args … not sure of the size impact
+-   could commit to a branch and have CCAO submodule that?
+
+Timmywil has first cut at Sizzle changes
+
+-   [https://github.com/timmywil/sizzle/compare/revamp](https://github.com/timmywil/sizzle/compare/revamp)
+-   currently -215
+
+jQuery.quickReady – land it now? (yep)
+
+Documentation
+
+-   New interfaces like quickReady?
+-   Animation hooks Tween etc.
+-   Other things needing docs?
+
+Blogs and messaging (Dave)
+
+-   Deprecation — [goo.gl/Vzaxa](http://goo.gl/Vzaxa) (team only)
+-   Size and “bloat”, call for participation on CCAO
+
+Build process
+
+-   code will used shared\_var
+-   Use “grunt watch” to auto-build
+
+gnarf may try to move Trac to a new server

--- a/minutes/core/2012-05-14.md
+++ b/minutes/core/2012-05-14.md
@@ -1,0 +1,46 @@
+May 14, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, mikesherov, rwaldron, timmywil, gnarf  
+ Time: Noon ET
+
+Official Agenda:  
+
+1.8
+
+Need to knock down the list of remaining 1.8 items
+
+-   [http://goo.gl/ewuKx](http://goo.gl/ewuKx)
+-   Sizzle? (reminder: land CCAO changes there)
+
+Manual modularity
+
+-   Allow build without effects, ajax, css even?
+-   Opened a ticket:
+    [http://bugs.jquery.com/ticket/11767](http://bugs.jquery.com/ticket/11767)
+-   gnarf will look at animation modularity
+-   jaubourg can do ajax part?
+-   dave will look at grunt
+
+Documentation
+
+-   Deprecations – dave created tickets
+-   Animation hooks Tween etc. — gnarf can you outline?
+-   Other things needing docs?
+
+Size and “bloat”, call for participation on CCAO
+
+mikesherov asks: what browser “versions” do we support?
+
+-   versions are a shorthand for focusing support effort?
+-   specific bug was
+    [http://bugs.jquery.com/ticket/11696](http://bugs.jquery.com/ticket/11696)
+-   only in Safari 5.0.x
+-   Only about 15% of Safari is 5.0.x and Safari total is \~15%
+-   [http://www.statowl.com/web\_browser\_usage\_by\_subversion.php?1=1&timeframe=last\_6&interval=month&chart\_id=4&fltr\_br=&fltr\_os=&fltr\_se=&fltr\_cn=&holder%5B%5D=safari&limit%5B%5D=5&lock\_date=1](http://www.statowl.com/web_browser_usage_by_subversion.php?1=1&timeframe=last_6&interval=month&chart_id=4&fltr_br=&fltr_os=&fltr_se=&fltr_cn=&holder%5B%5D=safari&limit%5B%5D=5&lock_date=1)
+-   Not worth a lot of effort
+
+Bug triage meeting Thursday 8pm eastern time \#jquery-dev
+
+-   all the cool kids will attend
+

--- a/minutes/core/2012-05-25.md
+++ b/minutes/core/2012-05-25.md
@@ -1,0 +1,63 @@
+May 21, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, gibson042, mikesherov, rwaldron, Krinkle,
+scott\_gonzalez  
+ Time: Noon ET
+
+Official Agenda:
+
+Unit test failures
+
+-   Safari 5.0
+-   [http://swarm.jquery.org/index.php?action=runresults&run\_id=990&client\_id=7222](http://swarm.jquery.org/index.php?action=runresults&run_id=990&client_id=7222)
+-   dave Y U CLOSE PULL
+    [https://github.com/jquery/jquery/pull/728](https://github.com/jquery/jquery/pull/728)
+-   Browserstack is having issues
+-   after the fix above, only IE6 problems remain
+
+JHP for serving – land it?
+
+-   Need to coordinate with testswarm – Krinkle?
+-   Can’t land until swarm issues are resolved
+
+Need update to README to reflect current build process
+
+Manual modularity
+
+effects – gibson042
+
+-   [https://github.com/jquery/jquery/pull/786](https://github.com/jquery/jquery/pull/786)
+-   grunt option to include/exclude modules, reusable
+
+jaubourg can do ajax part?
+
+Can we deprecate Boolean attrHooks? — probably not
+
+-   [http://bugs.jquery.com/ticket/11734](http://bugs.jquery.com/ticket/11734)
+-   jQuery(“\<input type=checkbox\>”, { checked: true }); — patch to
+    make it work
+-   Deprecate jQuery(html, props)  too? — nope
+
+Compat repo for deprecated/removed stuff?
+
+-   Separate plugins including compressed versions
+-   Combined plugin with everything
+-   “Debug” version with console.warn msgs?
+-   We can host these on code.jquery.com
+
+Documentation
+
+-   Deprecations – dave created tickets, will finish docs
+-   Animation hooks Tween etc. — gnarf can you outline?
+-   Other things needing docs?
+
+Remaining 1.8 items
+
+-   [http://goo.gl/ewuKx](http://goo.gl/ewuKx)
+-   Sizzle? (reminder: land CCAO changes there)
+
+FYI: wycats trying to get standards to help our selector impl
+
+-   [https://gist.github.com/c1d6c49873bbba3589b7](https://gist.github.com/c1d6c49873bbba3589b7)
+

--- a/minutes/core/2012-06-05.md
+++ b/minutes/core/2012-06-05.md
@@ -1,0 +1,100 @@
+****June 4, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode & Chat on Google Docs  
+ Attending: DaveMethvin, gnarf, rwaldron, gibson042, rworth,
+danheberden  
+ Time: Noon ET  
+****
+
+****(IRC issues during the meeting;  \#jquery-meeting did not log
+everything)****
+
+****  
+ Official Agenda:****
+
+Getting help for infra and new docs sites?
+
+-   rworth:
+
+Schedule for 1.8 release
+
+-   beta before the conf
+-   bug triage meeting – Wednesday noon?
+
+Unit test failures
+
+[http://swarm.jquery.org/job/208](http://swarm.jquery.org/job/208)
+
+-   effects in IE? gnarf can’t look right now – can someone else
+    -mikesherov
+
+[http://swarm.jquery.org:8080/job/jQuery%20Core](http://swarm.jquery.org:8080/job/jQuery%20Core/)/
+
+strip\_iife branch ready to land – if we want to
+
+-   line numbers in errors are for the built code – not the src/files.js
+-   We seem to think that the benefits outway the debugging/development
+    minor hassle
+-   source maps?
+-   LAND IT!
+
+JHP for serving – land it?
+
+-   Need to coordinate with testswarm – Krinkle?
+-   Can’t land until jenkins issues are resolved
+
+Need update to README to reflect current build process
+
+-   There is a “draft” of these instructions in the strip\_iife branch
+-   LAND IT!
+
+Closure Compiler Advanced Optimizations (CCAO)
+
+-   Talk with Chad Killingsworth
+-   He will rebase against 1.8 later this month
+-   We will land most of the CCAO unit test changes
+-   timmywil, did CCAO changes land in Sizzle?
+
+Manual modularity
+
+Landed gibson042′s modularity for effects
+
+Others?
+
+-   ajax?
+-   css and dimensions – mikesherov
+
+Compat repo for deprecated/removed stuff? – dave
+
+-   Separate plugins including compressed versions
+-   Combined plugin with everything
+-   “Debug” version with console.warn msgs?
+-   We can host these on code.jquery.com, perhaps other CDNs
+
+Documentation
+
+Deprecations – dave created tickets, will finish docs
+
+Animation hooks Tween etc. — gnarf to outline
+
+Other things needing docs?
+
+.css(‘width’) respects box-sizing, .width() doesn’t; dimension setters –
+mikesherov
+
+vendor prefixing
+
+-   automatic – ‘boxSizing’ will get ‘MozBoxSizing’
+-   can create cssHooks for vendor-prefixed, which get priority over
+    non-prefixed
+
+Remaining 1.8 items
+
+-   [http://goo.gl/ewuKx](http://goo.gl/ewuKx)
+
+New items?
+
+-   Adding new callbacks for animations –
+    [http://bugs.jquery.com/ticket/11797](http://bugs.jquery.com/ticket/11797)
+    – gibson
+

--- a/minutes/core/2012-06-11.md
+++ b/minutes/core/2012-06-11.md
@@ -1,0 +1,63 @@
+June 4, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode & Chat on Google Docs  
+ Attending: DaveMethvin, rworth, gibson042, timmywil, jaubourg,
+rwaldron, mikesherov  
+ Time: Noon ET
+
+Official Agenda:
+
+Schedule for 1.8 release
+
+-   beta before the conf (aim for June 19th)
+-   move quickIs to sizzle?
+-   land
+    [https://github.com/jquery/jquery/pull/808](https://github.com/jquery/jquery/pull/808)
+-   bug triage
+-   remaining 1.8 items: [http://goo.gl/ewuKx](http://goo.gl/ewuKx)
+
+Unit test failures (IE only)
+
+[https://github.com/jquery/jquery/pull/795](https://github.com/jquery/jquery/pull/795)
+
+-   need an update to QUnit for the fix to raises()
+
+Manual modularity
+
+Great progress here, thanks guys!
+
+mikesherov added dependency mgmt
+
+jaubourg working on ajax
+
+Need a simpler tool (not necessarily by release)
+
+-   complexity prevents wrong ppl using it
+
+Drupal? this isn’t for their use case (dave imo)
+
+use AMD wrappers? watch out for cross-module variables!
+
+Compat repo for deprecated/removed stuff? – dave
+
+-   Separate plugins including compressed versions
+-   Combined plugin with everything
+-   “Debug” version with console.warn msgs?
+
+Documentation
+
+Deprecations – dave created tickets, will finish docs
+
+Animation hooks Tween etc. — gnarf to outline
+
+Other things needing docs?
+
+.css(‘width’) respects box-sizing, .width() doesn’t; dimension setters –
+mikesherov
+
+vendor prefixing
+
+-   automatic – ‘boxSizing’ will get ‘MozBoxSizing’
+-   can create cssHooks for vendor-prefixed, which get priority over
+    non-prefixed
+

--- a/minutes/core/2012-06-22.md
+++ b/minutes/core/2012-06-22.md
@@ -1,0 +1,91 @@
+June 18, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode & Chat on Google Docs  
+ Attending: DaveMethvin, mikesherov, rwaldron, gibson042, gnarf,
+timmywil  
+ Time: Noon ET
+
+Official Agenda:  
+
+1.8 release
+
+Dave has a trip tomorrow (Tuesday)
+
+-   Thursday 6/21? yes
+
+Will we EVAR PASS unit tests in Jenkins?
+
+need to use documentMode instead of ua sniff for ie8 fail
+
+add IE=Edge to TestSwarm as well? (already there!)
+
+[https://github.com/jquery/jquery/commit/a416e2ba0d10bf1e1e94b5d023543d38ad08fcfb](https://github.com/jquery/jquery/commit/a416e2ba0d10bf1e1e94b5d023543d38ad08fcfb)
+
+-   TestSwarm already has that, and the iframe sets it, too
+
+remaining 1.8 items: [http://goo.gl/ewuKx](http://goo.gl/ewuKx)
+
+Anything you think should/must land?
+
+-   animation events (already a pull)
+
+Bugs can still be fixed after the beta
+
+If you own a ticket and won’t get to it for 1.8, switch to 1.next
+
+Anything happen on createContextualFragment or insertAdjacentHTML?
+
+-   Yehuda said he had some work
+-   Conclusion: pushed out of 1.8
+
+Promises: We can’t make ours “Promise/A compliant”
+
+-   Make sure we’re not advertising such
+-   Todo: document Promise/Q
+
+Brainstorming on \$.parseHTML
+
+Can be looser than the \$(html) parse
+
+-   Timmy mentioned possible fixes there
+-   Would like to simplify/restrict “looks like html”
+-   (starts-with “\<” has been pushed, 6/20)
+
+Want some way to control whether scripts run
+
+-   \$.parseHTML(html, { allowScripts: true }); ?
+-   distinguish allow inline vs. external?
+
+Manual modularity
+
+-   Done I think
+-   Plan a blog entry for it
+
+Compat repo for deprecated/removed stuff? – Dave (still todo)
+
+-   Separate plugins including compressed versions
+-   Combined plugin with everything
+-   “Debug” version with console.warn msgs?
+
+Documentation
+
+Deprecations – Dave DONE except for global ajax events
+
+Animation hooks Tween etc. — gnarf DONE
+
+Other things needing docs?
+
+.css(‘width’) respects box-sizing, .width() doesn’t; dimension setters –
+mikesherov
+
+vendor prefixing
+
+-   automatic – ‘boxSizing’ will get ‘MozBoxSizing’
+-   can create cssHooks for vendor-prefixed, which get priority over
+    non-prefixed
+
+git deploy: Jenkins is doing that now (before running TestSwarm)
+
+-   needs an update in build to include commit hash, can be passed by
+    Jenkins
+

--- a/minutes/core/2012-07-09.md
+++ b/minutes/core/2012-07-09.md
@@ -1,0 +1,45 @@
+July 9, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, gibson042, timmywil, jaubourg, gnarf,
+scott\_gonzalez  
+ Time: Noon ET
+
+Official Agenda:  
+
+Sizzle
+
+-   Sizzle docs updated:
+    [https://github.com/jquery/sizzle/wiki/Sizzle-Documentation](https://github.com/jquery/sizzle/wiki/Sizzle-Documentation)
+-   Blog post last week:
+    [http://blog.jquery.com/2012/07/04/the-new-sizzle/](http://blog.jquery.com/2012/07/04/the-new-sizzle/)
+-   Closure pull needs updated (Dave will ping Chad)
+
+Ajax
+
+Need to refactor ajax dependencies to new file
+
+-   serialize, param, parseJSON, parseXML
+-   otherwise it’s hard to use other ajax impls like \$.jsonp
+-   jaubourg to change
+
+Making promises resolve async
+
+jaubourg has a possible solution
+
+-   separate method to resolve sync
+
+dave will start thread in jquery-devs-team
+
+jQuery.unique – no action to be taken
+
+What needs to be done for beta2?
+
+-   Full test with UI passing? timmywil says YES it’s done
+-   still need to fix “:not( .foo ):has( bar )”
+-   What should “:contains( asdf )” match (spaces) — gibson042′s patch
+    fixes
+-   Possible effects issue, gnarf to investigate – scott already fixed!
+    WIN!
+-   beta2 tomorrow
+

--- a/minutes/core/2012-07-16.md
+++ b/minutes/core/2012-07-16.md
@@ -1,0 +1,49 @@
+July 16, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin,  
+ Time: Noon ET
+
+Official Agenda:  
+
+Sizzle
+
+Several pull requests from gibson042 to land
+
+Should this need escaping?
+[http://bugs.jquery.com/ticket/12087](http://bugs.jquery.com/ticket/12087)
+
+-   NO, gibson042 to look at it
+
+Ajax
+
+jaubourg refactored serialize
+
+Other things to split from ajax.js?
+
+\$.sjax is dead, no need to create it
+
+As of 1.8
+
+-   use of ajaxSettings.traditional DIRECTLY with serialize() is
+    deprecated
+-   new argument to serialize() sends traditional
+-   \$.ajax usage is unchanged, it will pass the flag from ajaxSettings
+
+jQuery 1.8RC1?
+
+Target next week
+
+Land Sizzle fixes
+
+jaubourg to look at issue with Deferred passed as \`this\` to
+.progress()
+
+Fix several new bugs
+
+-   right-click delegation
+
+MUST be released with jQuery UI 1.8.x refresh
+
+-   Needs fixes for Sizzle and curCSS changes
+

--- a/minutes/core/2012-07-23.md
+++ b/minutes/core/2012-07-23.md
@@ -1,0 +1,31 @@
+July 23, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, rwaldron, gnarf, timmywil, scott\_gonzalez  
+ Time: Noon ET
+
+Official Agenda:  
+
+Sizzle
+
+Landed gibson042 pulls
+
+Switched to using Sizzle unit tests with Sizzle HTML
+
+-   Easier to maintain
+-   “Scoops out” main page HTML and replaces
+
+jQuery 1.8RC1?
+
+This week — Thursday?
+
+GET TESTING TO WORK IN BROWSERSTACK (Dave)
+
+What else needs to land?
+
+-   Effects bug list is rather long (gnarf/timmywil reviewing)
+
+MUST be released with jQuery UI 1.8.x refresh
+
+-   scott\_gonzalez to release this week
+

--- a/minutes/core/2012-07-30.md
+++ b/minutes/core/2012-07-30.md
@@ -1,0 +1,46 @@
+****July 30, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, timmywil, mikesherov, jaubourg,
+scott\_gonzalez, rwaldron, gnarf  
+ Time: Noon ET****
+
+Official Agenda:
+
+Unit tests PASSING!
+
+-   Occasional flakiness in timing-related tests
+-   I’m tweaking the timers as they occur to reduce the odds
+
+jQuery 1.8
+
+Patches landed — do we need an RC2?
+
+Final release date?
+
+-   I’m traveling all this week but could do a release
+-   Otherwise, August 7?
+
+[http://bugs.jquery.com/ticket/12158](http://bugs.jquery.com/ticket/12158)
+ (throws)
+
+Leave it quoted for 1.8, warn that it’s coming out after that
+
+“it was put in to prevent YUI compressor from breaking”
+
+-   [http://yuilibrary.com/projects/yuicompressor/ticket/2528161](http://yuilibrary.com/projects/yuicompressor/ticket/2528161)
+
+[https://github.com/jquery/sizzle/pull/139](https://github.com/jquery/sizzle/pull/139)(fixes
+to pseudo argument cases)
+
+-   timmywil is -1
+-   Need perf tests to see effects on relatively common cases
+
+Scott has UI 1.8.22 out, compatible with core 1.8
+
+Mobile bitten by removal of \$.attrFn! (undocumented interface)
+
+Avoid private arguments to our public APIs
+
+-   complicates duck punching
+

--- a/minutes/core/2012-08-06.md
+++ b/minutes/core/2012-08-06.md
@@ -1,0 +1,17 @@
+August 6, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, gibson042, gnarf  
+ Time: Noon ET
+
+Official Agenda:  
+
+jQuery 1.8
+
+Ship tomorrow? Yes!
+
+Low-risk patches to land?
+
+-   [http://bugs.jquery.com/ticket/10394](http://bugs.jquery.com/ticket/10394)
+-   [http://bugs.jquery.com/ticket/12203](http://bugs.jquery.com/ticket/12203)
+

--- a/minutes/core/2012-08-13.md
+++ b/minutes/core/2012-08-13.md
@@ -1,0 +1,36 @@
+August 13, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, mikesherov, gibson042, timmywil, jaubourg  
+ Time: Noon ET
+
+Official Agenda:  
+
+Thanks for jumping in on ticket triage!
+
+-   General policy: jsFiddle/jsbin preferred but not required
+-   Sometimes hard to repro ajax or .ready() stuff there
+-   If you find out anything, make a note on the ticket
+
+jQuery 1.8 — The Aftermath
+
+Tickets to discuss
+
+[http://bugs.jquery.com/ticket/12269](http://bugs.jquery.com/ticket/12269)
+
+-   .width() needs to know box-sizing now
+-   Requires gCS which is 100x slow, esp in Chrome
+-   Most people really want .css(“width”)
+-   For now, advise that they use it \^\^
+-   mikesherov to look at options for speeding up .width()
+
+Tickets and PRs we need to land (mark as blocker)
+
+-   [https://github.com/jquery/jquery/pull/878](https://github.com/jquery/jquery/pull/878)
+-   timmywil will have the complex pseudo fix soon
+
+Stumpers?
+
+-   [http://bugs.jquery.com/ticket/12282](http://bugs.jquery.com/ticket/12282)
+
+jQuery 1.8.1 for next week’s agenda

--- a/minutes/core/2012-08-20.md
+++ b/minutes/core/2012-08-20.md
@@ -1,0 +1,36 @@
+August 20, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, gibson042, jaubourg, rwaldron, timmywil (cameo
+by phone)  
+ Time: Noon ET
+
+Official Agenda:  
+
+jQuery 1.8.1
+
+RC or final? (depends on tix that land by then)
+
+This week:  Thursday?
+
+Tickets and PRs we need to land (mark as blocker)
+
+-   sizzle fixes (timmywil and/or gibson042)
+
+jQuery 1.9 & 2.0
+
+Mark your faves as “1.9-discuss” or “2.0-discuss” in the tracker
+
+Intentionally avoiding major rewrites in 1.9 — mostly just deletes
+
+Intend to release 1.9 and 2.0 very close to each other
+
+Aim for alpha after our hackfest in October?
+
+How can we avoid the 1.9.0 bug rush?
+
+How can we involve the community?
+
+-   Running blog posts about changes
+-   More alpha/beta releases?
+

--- a/minutes/core/2012-08-27.md
+++ b/minutes/core/2012-08-27.md
@@ -1,0 +1,74 @@
+August 27, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, timmywil, gibson042,  
+ Time: Noon ET
+
+Official Agenda:  
+
+jQuery 1.8.1
+
+Final or RC? Leaning towards final.
+
+Release day? Wednesday, Thursday?
+
+Things to emphasize in the 1.8.1 release blog post
+
+-   Dropped FF 3.6 support, tho Sizzle still has it
+
+No ticket but broken
+
+-   Wilto checked the Android 2.1 issue with .ready(), still there
+
+Tickets with patches
+
+[http://bugs.jquery.com/ticket/12403](http://bugs.jquery.com/ticket/12403)
+(UI-related selector fail)
+
+-   landed
+
+[http://bugs.jquery.com/ticket/12313
+(](http://bugs.jquery.com/ticket/12313)be kind to SVG on width/height)
+
+Tickets and PRs we need to land (blocker)
+
+[http://bugs.jquery.com/ticket/12392](http://bugs.jquery.com/ticket/12392)
+(created elements have a parent)
+
+[http://bugs.jquery.com/ticket/12359
+(](http://bugs.jquery.com/ticket/12359)XHTML again)
+
+-   fixed
+
+[http://bugs.jquery.com/ticket/12384](http://bugs.jquery.com/ticket/12384)(regression
+with .after)
+
+[http://bugs.jquery.com/ticket/12369](http://bugs.jquery.com/ticket/12369)
+(.find() and oldIE XML)
+
+[http://bugs.jquery.com/ticket/12346](http://bugs.jquery.com/ticket/12346)
+(.append multiple stuff)
+
+[http://bugs.jquery.com/ticket/12303](http://bugs.jquery.com/ticket/12303)
+(:first inside attribute values)
+
+[http://bugs.jquery.com/ticket/12337](http://bugs.jquery.com/ticket/12337)
+(.nth-child selector fail)
+
+-   marked as dup of 12205, fixed
+
+Full list of blockers
+
+-   [http://bugs.jquery.com/query?status=!closed&milestone=1.8.1&col=id&coll=summary&col=owner&col=component&order=priority](http://bugs.jquery.com/query?status=!closed&milestone=1.8.1&col=id&col=summary&col=owner&col=component&order=priority)
+
+Quick triage on new tickets
+
+-   [http://bugs.jquery.com/ticket/12406](http://bugs.jquery.com/ticket/12406)
+    (should we gold-plate oldIE support in 1.9?)
+-   [http://bugs.jquery.com/ticket/12402](http://bugs.jquery.com/ticket/12402)
+    (Promise.when feature request)
+-   [http://bugs.jquery.com/ticket/12399](http://bugs.jquery.com/ticket/12399)
+    (animations with transitions present)
+-   [http://bugs.jquery.com/ticket/12243](http://bugs.jquery.com/ticket/12243)
+    (mikesherov has a plan to deal with this)
+

--- a/minutes/core/2012-09-10.md
+++ b/minutes/core/2012-09-10.md
@@ -1,0 +1,63 @@
+September 10, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, mikesherov, gnarf, timmywil, gibson042,
+rwaldron  
+ Time: Noon ET
+
+Official Agenda:  
+
+jQuery 1.8.2
+
+Would like this to be the last in the 1.8 line
+
+Let’s be VERY conservative about fixes
+
+Blockers
+
+-   Delegated events perf regression
+-   Effects loop –
+    [http://bugs.jquery.com/ticket/12447](http://bugs.jquery.com/ticket/12447)
+
+[https://github.com/jquery/sizzle/pull/151](https://github.com/jquery/sizzle/pull/151)
+from gibson
+
+-   needed for regressions
+
+Performance suite for jQuery core
+
+We have a new suite for Sizzle
+[http://cl.ly/image/0C2V351c3y1a](http://cl.ly/image/0C2V351c3y1a)
+
+rwaldron will take the lead on Dromaeo adaptation
+
+-   /jquery/dromaeo repo created (thanks scott\_gonzalez)
+
+jQuery 1.9/2.0
+
+Fix common 1.9/2.0 problems early
+
+-   Removals from deprecations
+-   Bug fixes
+
+Branch 1.9 when common work is complete
+
+2.0 work to be done in master
+
+All open tickets should be in play
+
+Let’s do a ticket triage day before the Summit
+
+-   Thursday 9/10 7:30pm (invites sent)
+-   Decide which tix should be addressed before branch
+
+Do we need a public call for features? (no)
+
+-   Last one didn’t come up with useful feedback
+-   Not looking to add features this time around
+
+Aim for 1.9 beta in early December
+
+-   Long beta period since we’re removing a lot
+
+Aim for 2.0 beta … when? (1.9 beta +2 wks?)

--- a/minutes/core/2012-09-17.md
+++ b/minutes/core/2012-09-17.md
@@ -1,0 +1,58 @@
+September 17, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, timmywil, rwaldron, gibson042, mikesherov  
+ Time: Noon ET
+
+Official Agenda:  
+
+jQuery 1.8.2
+
+Would like this to be the last in the 1.8 line
+
+Let’s stay conservative
+
+-   No regressions
+-   Only low-risk, high-impact bugs
+
+Blockers
+
+-   The Big Sizzle
+-   Others??
+
+Ship date: Thu Sept 20?
+
+Bug triage meeting last Thursday
+
+-   Triaged all new bugs
+-   Triaged 1.8.2 bugs
+
+Assigned tickets
+
+Let’s only grab tix when they can be worked on soon
+
+-   Weekly status on assigned tickets
+-   Owned tix discourage others from looking/fixing
+-   Can we get some of these done during the hackfest?
+
+Currently assigned
+
+-   [http://bugs.jquery.com/query?status=assigned&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority](http://bugs.jquery.com/query?status=assigned&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority)
+
+1.9/2.0 split
+
+-   land any post-1.8.2 fixes common to both
+-   Do the split after that, post-hackathon
+
+1.9 direction on oldIE
+
+-   Fix anything that’s practical (a dozen or so lines of code max?)
+-   Wontfix the rest; explain why (perf, size, side-effects) and give
+    workarounds
+
+1.9 voting
+
+-   Let’s start voting next week (after 1.8.2 ships)
+-   Identify tickets that you think should be discussed/voted
+-   Don’t tag uncontroversial tickets that should just be done
+

--- a/minutes/core/2012-09-24.md
+++ b/minutes/core/2012-09-24.md
@@ -1,0 +1,66 @@
+****September 24, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, timmywil, gibson042, rwaldron, jaubourg (10
+minutes)  
+ Time: Noon ET****
+
+Official Agenda:
+
+jQuery 1.8.2 shipped — bugs?
+
+Landing common fixes before 1.9/2.0 split
+
+-   Should we tag those 1.8.3? (leave it as pre for now)
+-   Please ID those by next Monday (Oct 1)
+-   Let’s complete bug fixes before summit (Oct 15)
+
+The split(s) schedule
+
+1.9 split to occur post-Summit (Oct 22)
+
+-   master branch will be 1.9
+
+Remove deprecated features and stabilize
+
+Complete the compat plugin
+
+naming? I don’t like jquery-compat-1.9
+
+-   jquery-compat.js
+
+warns about using the features, patches support back in
+
+1.9 alpha/beta first, incorporate feedback
+
+2.0 split early December?
+
+-   master will stay 1.9 … branch will be 2.0
+
+Ticket votes for 1.9 (and 2.0, really)
+
+-   Let’s start voting/discussion this week
+-   [http://bugs.jquery.com/query?keywords=\~1.9-discuss&col=id&col=summary&col=milestone&col=component&order=priority](http://bugs.jquery.com/query?keywords=~1.9-discuss&col=id&col=summary&col=milestone&col=component&order=priority)
+
+SVG support
+
+-   Would like a deeper analysis before official support
+-   Okay with landing simple SVG fixes
+-   yet another one:
+    [http://jsfiddle.net/qqvzM/3/](http://jsfiddle.net/qqvzM/3/) (via
+    peol)
+
+[Trac
+problems](http://bugs.jquery.com/query?keywords=~1.9-discuss&col=id&col=summary&col=milestone&col=component&order=priority)
+
+-   [Still slow and
+    dumpy](http://bugs.jquery.com/query?keywords=~1.9-discuss&col=id&col=summary&col=milestone&col=component&order=priority)
+-   [Can I get access to edit new-ticket
+    page?](http://bugs.jquery.com/query?keywords=~1.9-discuss&col=id&col=summary&col=milestone&col=component&order=priority)
+
+[Assigned
+tickets](http://bugs.jquery.com/query?keywords=~1.9-discuss&col=id&col=summary&col=milestone&col=component&order=priority)
+
+-   [http://bugs.jquer](http://bugs.jquery.com/query?keywords=~1.9-discuss&col=id&col=summary&col=milestone&col=component&order=priority)[y.com/query?status=assigned&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority](http://bugs.jquery.com/query?status=assigned&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority)
+
+ 

--- a/minutes/core/2012-10-08.md
+++ b/minutes/core/2012-10-08.md
@@ -1,0 +1,49 @@
+October 8, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending:  
+ Time: Noon ET
+
+Official Agenda:  
+
+jQuery 1.8.3 this week
+
+essential bug fixes before the 1.9 branching
+
+Candidate tickets, if fixable without high risk of other regressions:
+
+-   [http://bugs.jquery.com/ticket/12626](http://bugs.jquery.com/ticket/12626)
+    (didn’t we wontfix this?)
+-   [http://bugs.jquery.com/ticket/12648](http://bugs.jquery.com/ticket/12648)
+-   [http://bugs.jquery.com/ticket/12671](http://bugs.jquery.com/ticket/12671)
+-   [http://bugs.jquery.com/ticket/12672](http://bugs.jquery.com/ticket/12672)
+-   [http://bugs.jquery.com/ticket/12673](http://bugs.jquery.com/ticket/12673)
+
+Aiming for Thursday
+
+jQuery Developer Summit
+
+Need to contact attendees at your table this week
+
+-   introduction and assessment (determine skill level)
+-   make sure they have prerequisites set up
+-   tee up some ideas from below based on their skills
+
+Code ideas
+
+-   move the 1.9 deprecated functions to the compat plugin
+-   Ditch the makefile
+-   Dave to review open tix for other candidates and add to Summit wiki
+-   Team can also handle assigned tickets
+-   Add infra todo to fix trac and new-ticket page?
+
+Ticket votes for 1.9 (and 2.0, really)
+
+-   Still need VOTEs!
+-   Need to get gibson042 on the official list, gnarf?
+-   [http://bugs.jquery.com/query?keywords=\~1.9-discuss&col=id&col=summary&col=milestone&col=component&order=priority](http://bugs.jquery.com/query?keywords=~1.9-discuss&col=id&col=summary&col=milestone&col=component&order=priority)
+
+Assigned tickets
+
+-   [http://bugs.jquery.com/query?status=assigned&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority](http://bugs.jquery.com/query?status=assigned&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority)
+-   

--- a/minutes/core/2012-10-22.md
+++ b/minutes/core/2012-10-22.md
@@ -1,0 +1,59 @@
+October 22, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: mikesherov, gibson042, gnarf, saiwong, timmywil (45 min
+late!)  
+ Time: Noon ET
+
+Official Agenda:  
+
+Commit privs for mikesherov & gibson042!
+
+jQuery 1.8.3 – Wednesday?
+
+-   based off pre-Summit commit
+-   last call for must-have patches
+
+Aftermath of Summit
+
+-   Feedback — worked well?
+-   Good candidates? Possibly engage for 1.9 work?
+-   Need to sort through and land patches
+-   [http://bugs.jquery.com/ticketgraph?days=150](http://bugs.jquery.com/ticketgraph?days=150)
+    low low
+
+Common standard for landing patches?
+
+-   Check for new author, ask to sign CLA, add to AUTHORS.txt
+-   rebase (possibly -i) on branch, then merge to master?
+-   Message: “Fix \#12345, short description of the ticket. Close
+    gh-123.”
+
+Authors file
+
+Promise/J – diff between our implementation and Promise/A
+
+-   Make .then() Promise/A compliant but leave the rest as-is?
+-   Need a thorough article on Promise semantics
+
+New speed tests?
+
+-   Blow away the junk currently in /speed, based on Slickspeed (2008)
+-   New tests based on Timmy’s stuff
+
+jQuery 1.9 changes (start of the 1.9 upgrade guide)
+
+-   [https://docs.google.com/document/d/1rYH6C10gOl0q5iQTxBcAGcS4ZAlt7tuFs3psHHnxJdk/edit\#](https://docs.google.com/document/d/1rYH6C10gOl0q5iQTxBcAGcS4ZAlt7tuFs3psHHnxJdk/edit#)
+
+1.9 voting – VOTE – next week we will discuss voted tix
+
+-   [http://bugs.jquery.com/query?keywords=\~1.9-discuss&order=priority](http://bugs.jquery.com/query?keywords=~1.9-discuss&order=priority)
+
+Assigned tickets
+
+-   There are TOO MANY ASSIGNED TICKETS
+-   Only claim stuff you are going to fix in the next couple of months
+-   Be realistic so others can try to tackle them, you can mentor if you
+    have specific thoughts about how they need to be done
+-   [http://bugs.jquery.com/query?status=assigned&group=owner&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority](http://bugs.jquery.com/query?status=assigned&group=owner&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority)
+-   

--- a/minutes/core/2012-10-29.md
+++ b/minutes/core/2012-10-29.md
@@ -1,0 +1,42 @@
+October 29, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: mikesherov, gnarf, gibson042, timmywil, petro  
+ Time: Noon ET
+
+Official Agenda:  
+
+jQuery 1.8.3 – Cancelled due to complexity and lack of serious bugs
+
+Per discussion last week, jQuery 1.9 in a branch, 2.0 will be master
+
+botio is dead, gnarf is moving to use mergatron
+
+Deprecate \$(html, props)? (leave for now but document that it sucks)
+
+-   whine whine whine but i like it
+-   the problem is the creating of attributes mostly
+-   plus the other special cases (one element etc)
+
+Create a tiny-plugin or one-liner repo?
+
+1.9 voting – triaged all tickets during the meeting, YAY!!
+
+-   http://bugs.jquery.com/query?keywords=\~1.9-discuss&col=id&col=summary
+
+— post-meeting notes –
+
+jQuery 1.9 tix – need to jump on these and finish
+
+Pull queue – whittling it down, about 14 left now
+
+Speed tests, mikesherov to blow off the old stuff?
+
+Assigned tickets
+
+-   Only claim stuff you are going to fix in the next couple of months
+    weeks
+-   Be realistic so others can try to tackle them, you can mentor if you
+    have specific thoughts about how they need to be done
+-   [http://bugs.jquery.com/query?status=assigned&group=owner&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority](http://bugs.jquery.com/query?status=assigned&group=owner&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority)
+-   

--- a/minutes/core/2012-11-05.md
+++ b/minutes/core/2012-11-05.md
@@ -1,0 +1,47 @@
+November 5, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, gibson042, gnarf, mikesherov, timmywil  
+ Time: Noon ET
+
+Official Agenda:  
+
+jQuery 1.8.3 – Back on again, animation bug
+
+-   Next week
+
+[http://github.com/jquery/jquery-compat](http://github.com/jquery/jquery-compat)
+
+Using github issues to track bugs
+
+still rough and unfinished, patches and updates welcome
+
+TODO
+
+Filter out warnings for .min version
+
+Update QUnit
+
+Add other deprecated items or warnings
+
+-   Note the warning for Quirks for example
+
+Update README, CONTRIBUTING, AUTHORS
+
+Create a tiny-plugin or one-liner repo?
+
+-   put in our own private repos, e.g., dmethvin/jquery-arrayops
+
+Mergatron status? middle of this week sez mikesherov
+
+Speed tests, mikesherov to blow off the old stuff?
+
+-   rwaldron to revive dromeo,dromeaaaaao, dave to bug
+
+Assigned tickets review for 1.9
+
+-   Be realistic about claiming so others can try to tackle them, you
+    can mentor if you have specific thoughts about how they need to be
+    done
+-   [http://bugs.jquery.com/query?status=assigned&group=owner&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority](http://bugs.jquery.com/query?status=assigned&group=owner&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority)
+-   

--- a/minutes/core/2012-11-12.md
+++ b/minutes/core/2012-11-12.md
@@ -1,0 +1,40 @@
+November 12, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, gnarf, timmywil, mikesherov  
+ Time: Noon ET
+
+Official Agenda:  
+
+jQuery 1.8.3 – Today!
+
+-   Last call for patches, but I’d prefer none more patched
+
+[http://bugs.jquery.com/ticket/12801](http://bugs.jquery.com/ticket/12801)
+
+-   Already sizzle issue, ticket closed
+
+[http://bugs.jquery.com/ticket/11290](http://bugs.jquery.com/ticket/11290)
+
+-   Should we allow leading whitespace in \$(”   \<tag ..\>”) detection?
+-   I’m leaning NO
+-   If it’s not a literal string, user should sanitize–or better, use
+    \$.parseHTML
+
+Create \$.select()? Could we just document the Sizzle entry point?
+
+Mergatron status?
+
+Speed tests
+
+Dave will ping recent new contribs and see if they want to grab
+unassigned tix
+
+Unassigned tickets
+
+-   [http://bugs.jquery.com/query?owner=&status=new&status=open&status=pending&status=reopened&milestone=1.9&group=component&col=id&col=summary&col=milestone&col=owner&col=changetime&report=506&order=owner](http://bugs.jquery.com/query?owner=&status=new&status=open&status=pending&status=reopened&milestone=1.9&group=component&col=id&col=summary&col=milestone&col=owner&col=changetime&report=506&order=owner)
+
+Assigned tickets review for 1.9; need volunteers for open tix
+
+-   [http://bugs.jquery.com/query?status=assigned&group=owner&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority](http://bugs.jquery.com/query?status=assigned&group=owner&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority)
+-   

--- a/minutes/core/2012-11-21.md
+++ b/minutes/core/2012-11-21.md
@@ -1,0 +1,30 @@
+****November 19, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, t**immywil, gnarf, rwaldron, jaubourg,
+mikesherov**  
+ Time: Noon ET****
+
+Official Agenda:
+
+Mergatron status?  Landing over the holiday this week, hopefully.
+
+Speed tests
+
+Document jQuery.find rather than creating jQuery.select? No, not for 1.9
+
+Dave will ping recent new contribs and see if they want to grab
+unassigned tix
+
+-   Created the message, just need to grab the email addrs
+
+Early beta of 1.9 week of December 2?
+
+Unassigned tickets
+
+-   [http://bugs.jquery.com/query?owner=&status=new&status=open&status=pending&status=reopened&milestone=1.9&group=component&col=id&col=summary&col=milestone&col=owner&col=changetime&report=506&order=owner](http://bugs.jquery.com/query?owner=&status=new&status=open&status=pending&status=reopened&milestone=1.9&group=component&col=id&col=summary&col=milestone&col=owner&col=changetime&report=506&order=owner)
+
+Assigned tickets review for 1.9; need volunteers for open tix
+
+-   [http://bugs.jquery.com/query?status=assigned&group=owner&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority](http://bugs.jquery.com/query?status=assigned&group=owner&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority)
+-   

--- a/minutes/core/2012-11-26.md
+++ b/minutes/core/2012-11-26.md
@@ -1,0 +1,57 @@
+November 26, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, gibson042, timmywil, mikesherov  
+ Time: Noon ET
+
+Official Agenda:  
+
+Mergatron status?  Currently in beta test, came up Saturday
+
+-   Issues?
+-   Summon with @jquerybot retest ?
+-   Whitelist of allowed summoners?
+
+Dave pinged 15 recent new contribs to suck them back in; no bites yet
+
+Availability over the next month?
+
+-   Dave out (teaching a class) December 2,3,4 in NYC but otherwise full
+    speed
+-   others?
+
+Early beta of 1.9 on December 9? Need the following by then:
+
+-   All major feature removals and behavior changes landed
+-   jquery-compat plugin supporting removed features and behaviors
+-   Upgrade guide describing major changes (Dave)
+
+Split for 2.0 (meaning 1.9-stable branch and 2.0 is master) on Dec 16?
+Later?
+
+-   Earlier split means we can start 2.0 sooner
+-   Also means we’ll need to cherry-pick and potentialy nasty merges
+    though
+-   Wait until post-split to land oldIE bug fix tickets
+-   We should aim to keep unit tests basically unchanged (leave oldIE
+    tests)
+
+Documentation – Upgrade guide
+
+-   [https://docs.google.com/document/d/1rYH6C10gOl0q5iQTxBcAGcS4ZAlt7tuFs3psHHnxJdk/edit\#heading=h.8fpe85x0x8wa](https://docs.google.com/document/d/1rYH6C10gOl0q5iQTxBcAGcS4ZAlt7tuFs3psHHnxJdk/edit#heading=h.8fpe85x0x8wa)
+-   Dave to reformat into Markdown
+-   Will have to be built manually based on tickets that land
+-   Please add notes for new stuff as you remember it, I can clean up
+
+Pull requests
+
+-   [https://github.com/jquery/jquery/pulls](https://github.com/jquery/jquery/pulls)
+
+Unassigned tickets
+
+-   [http://bugs.jquery.com/query?owner=&status=new&status=open&status=pending&status=reopened&milestone=1.9&group=component&col=id&col=summary&col=milestone&col=owner&col=changetime&report=506&order=owner](http://bugs.jquery.com/query?owner=&status=new&status=open&status=pending&status=reopened&milestone=1.9&group=component&col=id&col=summary&col=milestone&col=owner&col=changetime&report=506&order=owner)
+
+Assigned tickets review for 1.9; need volunteers for open tix
+
+-   [http://bugs.jquery.com/query?status=assigned&group=owner&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority](http://bugs.jquery.com/query?status=assigned&group=owner&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority)
+-   

--- a/minutes/core/2012-12-10.md
+++ b/minutes/core/2012-12-10.md
@@ -1,0 +1,84 @@
+December 10, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, rwaldron, gibson042  
+ Time: Noon ET
+
+Official Agenda:  
+
+Early beta of 1.9 on December 12:
+
+Ticket review (links below)
+
+[http://bugs.jquery.com/ticket/11290](http://bugs.jquery.com/ticket/11290)
+“looks like HTML” rule
+
+-   .charAt(0) === “\<” for now
+-   may allow whitespace depending on feedback
+-   compat plugin needs to restore old behavior
+
+[http://bugs.jquery.com/ticket/13011](http://bugs.jquery.com/ticket/13011)
+(“type” attribute)
+
+-   dave will land
+
+[http://bugs.jquery.com/ticket/12336](http://bugs.jquery.com/ticket/12336)
+(options.length = 0 for \$select.empty())
+
+****  
+****
+
+Pull Requests
+[https://github.com/jquery/jquery/pulls](https://github.com/jquery/jquery/pulls)
+
+[https://github.com/jquery/jquery/pull/1066](https://github.com/jquery/jquery/pull/1066)
+
+-   timmywil thinks maybe .defaultChecked can save us
+
+[https://github.com/jquery/jquery/pull/1065](https://github.com/jquery/jquery/pull/1065)
+
+-   zowie, let’s land it if this works everywhere
+
+[https://github.com/jquery/jquery/pull/1063](https://github.com/jquery/jquery/pull/1063)
+
+-   look into using .defaultValue
+
+[https://github.com/jquery/jquery/pull/1051](https://github.com/jquery/jquery/pull/1051)
+
+-   Want to discuss with jaubourg again
+-   gibson042 would like to hold until after
+    [https://github.com/jquery/jquery/pull/1060](https://github.com/jquery/jquery/pull/1060)
+-   dmethvin and gibson042 think it should go in ajax.js
+
+[https://github.com/jquery/jquery/pull/1027](https://github.com/jquery/jquery/pull/1027)
+
+-   timmywil to create a test from jQuery perspective
+
+[https://github.com/jquery/jquery/pull/1060](https://github.com/jquery/jquery/pull/1060)
+
+-   can’t land b/c causes errors in testswarm
+
+[https://github.com/jquery/jquery/pull/1047](https://github.com/jquery/jquery/pull/1047)
+
+-   GitHub’s a mess; close and request a fresh PR
+
+jquery-compat plugin supporting removed features and behaviors
+
+Documentation – Upgrade guide
+
+-   [https://docs.google.com/document/d/1rYH6C10gOl0q5iQTxBcAGcS4ZAlt7tuFs3psHHnxJdk/edit\#heading=h.8fpe85x0x8wa](https://docs.google.com/document/d/1rYH6C10gOl0q5iQTxBcAGcS4ZAlt7tuFs3psHHnxJdk/edit#heading=h.8fpe85x0x8wa)
+-   Please add notes for new stuff as you remember it, I can clean up
+
+Mergatron
+
+-   Upstream issues:
+    [http://github.com/snapinteractive/mergeatron/issues](http://github.com/snapinteractive/mergeatron/issues)
+
+Unassigned tickets
+
+-   [http://bugs.jquery.com/query?owner=&status=new&status=open&status=pending&status=reopened&milestone=1.9&group=component&col=id&col=summary&col=milestone&col=owner&col=changetime&report=506&order=owner](http://bugs.jquery.com/query?owner=&status=new&status=open&status=pending&status=reopened&milestone=1.9&group=component&col=id&col=summary&col=milestone&col=owner&col=changetime&report=506&order=owner)
+
+Assigned tickets review for 1.9; need volunteers for open tix
+
+-   [http://bugs.jquery.com/query?status=assigned&group=owner&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority](http://bugs.jquery.com/query?status=assigned&group=owner&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority)
+-   

--- a/minutes/core/2013-01-04.md
+++ b/minutes/core/2013-01-04.md
@@ -1,0 +1,131 @@
+December 31, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, gibson042, rwaldron, mikesherov  
+ Time: Noon ET
+
+Official Agenda:  
+
+Landing 2.0 changes
+
+jQuery 2.0 needs browserset “popular-no-old-ie”
+
+want to keep the support.js unit tests
+
+-   they let us know when it’s safe to remove a check
+
+Stale code in the repo
+
+-   Strategy for keeping and maintaining code?
+-   Remove oldIE tests from 2.0 branch (dave)
+
+Perf testing
+
+-   Need some to prevent perf regressions and prove 2.0 improvements
+-   focus on big-picture hot paths
+-   mikesherov and rwaldron to talk this week
+
+Style guide
+
+-   rwaldron proposes using js-beautify
+-   Let’s find a way to automate/standardize using this
+-   Perhaps a grunt task, and instructions in the contributing/readme?
+
+Unassigned tickets
+
+-   [http://bugs.jquery.com/query?owner=&status=new&status=open&status=pending&status=reopened&milestone=1.9&group=component&col=id&col=summary&col=milestone&col=owner&col=changetime&report=506&order=owner](http://bugs.jquery.com/query?owner=&status=new&status=open&status=pending&status=reopened&milestone=1.9&group=component&col=id&col=summary&col=milestone&col=owner&col=changetime&report=506&order=owner)
+
+Assigned tickets review for 1.9; need volunteers for open tix
+
+-   [http://bugs.jquery.com/query?status=assigned&group=owner&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority](http://bugs.jquery.com/query?status=assigned&group=owner&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority)
+
+  
+ December 17, 2012  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, gibson042, mikesherov  
+ Time: Noon ET
+
+Official Agenda:  
+
+Beta today:
+
+-   Blog post:
+    [http://blog.jquery.com/2012/12/17/jquery-1-9-beta-1-released/](http://blog.jquery.com/2012/12/17/jquery-1-9-beta-1-released/)
+-   Upgrade guide:
+    [http://jquery.com/upgrade-guide/1.9/](http://jquery.com/upgrade-guide/1.9/)
+
+Renamed jQuery Compat to jQuery Migrate – Thanks snover!
+
+[https://github.com/jquery/jquery-migrate](https://github.com/jquery/jquery-migrate)
+
+Where should bugs be handled for it? GITHUB
+
+-   Originally I thought Trac, but perhaps Github would be easier?
+-   Probably not that many bugs (haha)
+-   Just got our first bug
+
+jQuery 2.0 Pass One – Who wants to do some DELETING?
+
+For pass 1 let’s mainly remove hacks and do simple refactors
+
+-   Remove oldIE hacks
+-   Simple rewrites using ES5 features if they save code
+
+Don’t make any changes to unit tests (special dispensation required)
+
+Make pull requests prefixed with “2.0″ for review
+
+Branch off 1.9-stable next Monday if possible
+
+2.0 alpha by December 31 (two weeks)?
+
+Do we need tickets? No functional changes so I don’t think we do
+
+while making changes, normalize any browser-specific hacks to
+
+-   // Support: browser version (e.g., Support: Opera \<11.5, IE \< 9)
+
+What about Sizzle?
+
+-   Factoring out oldIE probably won’t pay off
+-   Explore a simple querySelectorAll/matchesSelector alternate impl
+
+Specific interest? Grab them now, or later
+
+-   ajax – dave
+-   attributes – timmy
+-   callbacks – dave (no changes; try/finally fireWith at some point?)
+-   core – Rick
+-   css – dave (about -300 gz)
+-   data – Rick
+-   deferred – dave (no changes)
+-   dimensions –  dave (just a comment to remove, so later)
+-   effects
+-   event – dave (about -520 gz)
+-   manipulation – Rick would like to work with Richard Gibson on this
+    :)
+-   offset – dave (no changes)
+-   queue – dave (no changes)
+-   serialize – dave (no changes)
+-   support – perhaps clean this up after we land the other stuff?
+-   traversing – orkel expressed interest, dave can back him up
+-   build and testswarm changes – dave, with help
+
+grunt 0.4 – wait until after Jan 1 before deploying
+
+WE MUST FIX THE IE8 TWO PIXEL BUG
+
+Mergeatron
+
+-   Upstream issues:
+    [http://github.com/snapinteractive/mergeatron/issues](http://github.com/snapinteractive/mergeatron/issues)
+
+Unassigned tickets
+
+-   [http://bugs.jquery.com/query?owner=&status=new&status=open&status=pending&status=reopened&milestone=1.9&group=component&col=id&col=summary&col=milestone&col=owner&col=changetime&report=506&order=owner](http://bugs.jquery.com/query?owner=&status=new&status=open&status=pending&status=reopened&milestone=1.9&group=component&col=id&col=summary&col=milestone&col=owner&col=changetime&report=506&order=owner)
+
+Assigned tickets review for 1.9; need volunteers for open tix
+
+-   [http://bugs.jquery.com/query?status=assigned&group=owner&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority](http://bugs.jquery.com/query?status=assigned&group=owner&col=id&col=summary&col=owner&col=milestone&col=changetime&report=506&order=priority)
+-   

--- a/minutes/core/2013-01-25.md
+++ b/minutes/core/2013-01-25.md
@@ -1,0 +1,38 @@
+January 21, 2013  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, timmywil, gibson042, mikesherov  
+ Time: Noon ET
+
+Official Agenda:
+
+Swarm failures
+
+-   2.0 is the grunt issue only?
+-   can copy package.json deps from 1.9
+
+jQuery 1.9.1 date?
+
+next week, early
+
+.apply( x, NodeList) doesn’t work on qtwebkit
+[http://bugs.jquery.com/ticket/13282](http://bugs.jquery.com/ticket/13282)
+
+-   gibson042 to back out the optimization
+
+IE\<=8 doesn’t sort nodes right
+[http://bugs.jquery.com/ticket/13281](http://bugs.jquery.com/ticket/13281)
+
+jQuery 2.0 beta2/final date?
+
+-   beta2 next week?
+-   final? no hurry i guess
+
+jQuery 1.9
+
+-   Shipped!
+
+Unassigned tickets
+
+-   [http://bugs.jquery.com/query?owner=&status=new&status=open&status=pending&status=reopened&milestone=1.9.1&group=component&col=id&col=summary&col=milestone&col=owner&col=changetime&report=506](http://bugs.jquery.com/query?owner=&status=new&status=open&status=pending&status=reopened&milestone=1.9&group=component&col=id&col=summary&col=milestone&col=owner&col=changetime&report=506&order=owner)
+-   

--- a/minutes/core/2013-02-06.md
+++ b/minutes/core/2013-02-06.md
@@ -1,0 +1,68 @@
+February 4, 2013  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, rwaldron, timmywil, gibson042, mikesherov,
+jaubourg, orkel  
+ Time: Noon ET
+
+Official Agenda:
+
+jQuery 1.9.1
+
+TODAY
+
+TestSwarm isn’t working AT ALL right now (natch)
+
+Any other changes to be landed?
+
+-   [https://github.com/jquery/jquery/pull/1155](https://github.com/jquery/jquery/pull/1155)
+-   [https://github.com/jquery/jquery/pull/1152](https://github.com/jquery/jquery/pull/1152)
+-   [https://github.com/jquery/jquery/pull/1147](https://github.com/jquery/jquery/pull/1147)
+
+jQuery Migrate 1.1.0
+
+-   May need a 1.1.1 to remove “use strict” there too
+
+Build issues
+
+grunt working well enough to wait for 0.4.0 final
+
+still need to restore compare-size
+
+stupid sourceMappingURL location issue
+
+Need to check our build code when we upgrade Uglify:
+
+-   [https://github.com/mishoo/UglifyJS2/issues/108](https://github.com/mishoo/UglifyJS2/issues/108)
+
+Swarm failures
+
+-   Seeing focus issues on Firefox, need to double-check
+
+jQuery 2.0 beta2
+
+Thursday?
+
+should have a beta to let people exercise changes to .data()
+
+-   Rick is working on performance optimizations for .data()
+
+Benchmarks
+
+-   [http://bugs.jquery.com/ticket/12778](http://bugs.jquery.com/ticket/12778)
+-   siovene (Salvatore Iovene) from Intel is going to take a shot at
+    this
+
+Version/feature correspondence
+
+-   Make 1.10 track 2.0? (So 1.11-\>2.1, 1.12-\>2.2, etc)
+-   in next major point release, don’t execute scripts by default
+
+Open tickets triage
+
+-   [http://bugs.jquery.com/ticket/13380](http://bugs.jquery.com/ticket/13380)
+-   [http://bugs.jquery.com/ticket/13379](http://bugs.jquery.com/ticket/13379)
+-   [http://bugs.jquery.com/ticket/13378](http://bugs.jquery.com/ticket/13378)
+-   [http://bugs.jquery.com/ticket/13376](http://bugs.jquery.com/ticket/13376)
+-   [http://bugs.jquery.com/query?owner=&status=!closed](http://bugs.jquery.com/query?owner=&status=new&status=open&status=pending&status=reopened&milestone=1.9&group=component&col=id&col=summary&col=milestone&col=owner&col=changetime&report=506&order=owner)
+-   

--- a/minutes/core/2013-02-15.md
+++ b/minutes/core/2013-02-15.md
@@ -1,0 +1,54 @@
+February 12, 2013  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, rwaldron, orkel, gibson042, siovene, timmywil  
+ Time: Noon ET
+
+Official Agenda:
+
+Siovene update/discussion on perf
+
+-   Still looking for ideas on organization, tests, etc
+
+jQuery 2.0b2
+
+-   This week – Day?
+-   Stuff to be done before it ships? No
+
+Things still needed for 2.0 final
+
+Optional qSA/mS Sizzle stub
+
+-   [http://bugs.jquery.com/ticket/13434](http://bugs.jquery.com/ticket/13434)
+
+jQuery Migrate 1.1.1 late this week — Dave
+
+Todos marked in Github issue tracker:
+
+-   [https://github.com/jquery/jquery-migrate/issues?milestone=3](https://github.com/jquery/jquery-migrate/issues?milestone=3&state=open)
+
+jQuery 1.9.2 — I think we can wait a couple of weeks
+
+Version/feature correspondence (from last week)
+
+-   Make 1.10 track 2.0? (So 1.11-\>2.1, 1.12-\>2.2, etc)
+-   in next major point release, don’t execute scripts by default
+-   Let’s leave this an open issue until we know what might need to be
+    in each version
+
+bugs.jquery.com
+
+-   New home page to improve people’s reporting
+-   e.g., docs issues go to api.jquery.com
+
+Open tickets triage
+
+[http://bugs.jquery.com/ticket/13428](http://bugs.jquery.com/ticket/13428)
+
+-   Lets hold off on action for now, potentially document that native
+    events should not depend on using trigger data and use
+    .triggerHandler if you need to pass data
+
+[http://bugs.jquery.com/ticket/13393](http://bugs.jquery.com/ticket/13393)
+
+http://bugs.jquery.com/query?status=new&report=505&order=priority

--- a/minutes/core/2013-03-12.md
+++ b/minutes/core/2013-03-12.md
@@ -1,0 +1,79 @@
+March 11, 2013  
+ Minutes (Notes) of the meeting of jQuery  
+ Location: \#jquery-meeting on Freenode  
+ Attending: DaveMethvin, timmywil, mikesherov, rwaldron, orkel  
+ Time: Noon ET
+
+Official Agenda:
+
+jQuery 2.0 Final
+
+Ship for jQuery Uk (April 19)?
+
+Stuff to be ironed out
+
+.data() implementation
+
+Use in node.js
+
+other?
+
+Sizzle ticket
+[https://github.com/jquery/sizzle/pull/193](https://github.com/jquery/sizzle/pull/193)
+
+-   Timmy will land
+
+jQuery 1.10
+
+Hard to move quickly on this, we’ve given zero notice
+
+Need to publicize changes (next bullet) and do a blog post
+
+-   Dave to do blog post ASAP
+
+Ship a month or two after 2.0? — mid-June would be Portland
+
+(Add these to Migrate Plugin and document NOW for 2.0/1.10 release)
+
+No script execute by default, must use \$.parseHTML
+
+-   Groundwork for XSS reduction, but not a complete fix atm
+-   This would make the no-leading-space restriction unnecessary?
+
+[http://bugs.jquery.com/ticket/13417](http://bugs.jquery.com/ticket/13417)
+domManip and empty text nodes
+
+[http://bugs.jquery.com/ticket/12838](http://bugs.jquery.com/ticket/12838)
+ \$.ajax hook point for domManip
+
+change Event.isTrigger from boolean to bitmask
+
+allow multiple args for .replaceWith
+([ref](https://github.com/jquery/jquery/pull/1163#commitcomment-2582368))
+
+jQuery 1.9.2 — Do we need one? (Doesn’t seem so, none scheduled)
+
+Documentation Day
+
+Tuesday March 12 8pm Eastern time \#jquery-dev
+
+Can we get the team together virtually to knock down the docs issues?
+
+-   [https://github.com/jquery/api.jquery.com/issues](https://github.com/jquery/api.jquery.com/issues)
+-   Move upgrade guide issues to api.jquery.com
+-   
+
+Document treatment of various node types ‘n stuff wrapped by jQuery
+
+-   What can be put in a set?
+-   What methods work with it?
+
+bugs.jquery.com
+
+-   New home page to improve people’s reporting — on Dave’s plate
+-   e.g., docs issues go to api.jquery.com
+
+Open tickets triage
+
+-   http://bugs.jquery.com/query?status=new&report=505&order=priority
+-   

--- a/minutes/testing/2011-04-26.md
+++ b/minutes/testing/2011-04-26.md
@@ -1,0 +1,18 @@
+QUnit
+
+-   A few minor fixes
+-   Dropped support for long-deprecated \#main in favor of
+    \#qunit-fixture. jQuery UI was already up-to-date, core got updated.
+-   Now on jQuery CDN with some extra info in the
+    header: [http://code.jquery.com/qunit/qunit-git.js](http://code.jquery.com/qunit/qunit-git.js) [http://code.jquery.com/qunit/qunit-git.css](http://code.jquery.com/qunit/qunit-git.css)
+-   Published CLI integration for PhantomJS, for now in a
+    branch: [https://github.com/jquery/qunit/blob/cli-phantomjs/test.js](https://github.com/jquery/qunit/blob/cli-phantomjs/test.js) -
+    still need to figure out how to bundle that along with node and
+    rhino integration
+    ([https://github.com/jquery/qunit/blob/cli/test/suite.js](https://github.com/jquery/qunit/blob/cli/test/suite.js))
+
+TestSwarm
+
+-   Working with Jonathan Sharp and Chad Meyers on Jenkins integration
+
+

--- a/minutes/testing/2011-05-07.md
+++ b/minutes/testing/2011-05-07.md
@@ -1,0 +1,14 @@
+Status
+
+-   Presented QUnit and TestSwarm at [sapo.pt](http://sapo.pt) and MS
+    HTML5 WebCamp in Lisbon, teasered Jenkins-Hudson integration
+-   Aloha Editor started using QUnit, posted some testing strategy
+    advice to their developer mailing list
+-   Nothing new on Jenkins-TestSwarm plugin, still working on that
+
+Todos:
+
+-   Need a roadmap for both QUnit and TestSwarm to find contributors.
+-   Look at code coverage tools, see if they could be used for jQuery
+    projects, maybe integrated with Jenkins
+

--- a/minutes/testing/2011-05-27.md
+++ b/minutes/testing/2011-05-27.md
@@ -1,0 +1,15 @@
+QUnit
+
+-   Escape the stacktrace output before setting it as innerHTML, since
+    it tends to contain \`\<\` and \`\>\` characters.
+    [https://github.com/jquery/qunit/commit/d4f23f8a882d13b71768503e2db9fa33ef169ba0](https://github.com/jquery/qunit/commit/d4f23f8a882d13b71768503e2db9fa33ef169ba0)
+
+TestSwarm
+
+-   Went through pull requests, now new swarmpath utilty method deals
+    with the contextpath issue and fixes several broken paths, as well
+    as order of commands in reset.sql, and correct instructions for
+    crontab
+-   Still waiting for update on Jenkins-TestSwarm plugin
+-   Some assistance for Aloha Editor team to use TestSwarm
+

--- a/minutes/testing/2011-06-05.md
+++ b/minutes/testing/2011-06-05.md
@@ -1,0 +1,1 @@
+No news this week.

--- a/minutes/testing/2011-06-10.md
+++ b/minutes/testing/2011-06-10.md
@@ -1,0 +1,4 @@
+No QUnit updates, though a dozen open pull requests need attention.
+
+No real TestSwarm updates, except that the promised Jenkins-TestSwarm
+plugin may still be coming along.

--- a/minutes/testing/2011-06-17.md
+++ b/minutes/testing/2011-06-17.md
@@ -1,0 +1,5 @@
+Roadmap planning in progress for both QUnit and TestSwarm.
+
+Hudson-TestSwarm plugin sourcecode now available, not yet tested or
+integrated
+anywhere: [https://github.com/appendto/hudson-testswarm](https://github.com/appendto/hudson-testswarm)

--- a/minutes/testing/2011-06-24.md
+++ b/minutes/testing/2011-06-24.md
@@ -1,0 +1,10 @@
+Created planning wiki for testing
+tools: [http://jquerytesting.pbworks.com](http://jquerytesting.pbworks.com/)
+
+Next steps:
+
+-   Flesh out roadmaps for QUnit and TestSwarm
+-   Started: [http://jquerytesting.pbworks.com/w/page/41556843/QUnit-Website](http://jquerytesting.pbworks.com/w/page/41556843/QUnit-Website)
+-   Started: [http://jquerytesting.pbworks.com/w/page/41615571/QUnit-CLI-Integration](http://jquerytesting.pbworks.com/w/page/41615571/QUnit-CLI-Integration)
+-   Recruit people to help and do a kickoff meeting
+

--- a/minutes/testing/2011-07-01.md
+++ b/minutes/testing/2011-07-01.md
@@ -1,0 +1,6 @@
+Planning QUnit website:
+[http://jquerytesting.pbworks.com/w/page/41556843/QUnit-Website](http://jquerytesting.pbworks.com/w/page/41556843/QUnit-Website)  
+Planning CLI integration, testing with npm and node.js:
+[http://jquerytesting.pbworks.com/w/page/41615571/QUnit-CLI-Integration](http://jquerytesting.pbworks.com/w/page/41615571/QUnit-CLI-Integration)
+
+Looking for contributors!

--- a/minutes/testing/2011-07-08.md
+++ b/minutes/testing/2011-07-08.md
@@ -1,0 +1,11 @@
+Extended recruiting efforts to @jquery Account on Twitter, first results
+visible on [QUnit issues, now properly
+labelled](https://github.com/jquery/qunit/issues?state=open). No date
+yet for kickoff meeting, figuring that out.
+
+Having people intersted on working on QUnit issues, TestSwarm issues,
+QUnit website and the Hudson-TestSwarm plugin, results pending.
+
+On the PR side: [InfoQ has a "virtual panel", covering QUnit and three
+other JS testing
+frameworks](http://www.infoq.com/articles/javascript-unit-testing).

--- a/minutes/testing/2011-07-15.md
+++ b/minutes/testing/2011-07-15.md
@@ -1,0 +1,6 @@
+Continuing recruiting efforts, with people intersted on working on QUnit
+issues, TestSwarm issues, QUnit website and the Hudson-TestSwarm plugin,
+results pending.
+
+Also used ARIA Hackathon and meetings around Toronto to recruit,
+including Mozilla.

--- a/minutes/testing/2011-07-24.md
+++ b/minutes/testing/2011-07-24.md
@@ -1,0 +1,6 @@
+-   Started jQuery Testing Team Skype group with Chad, Katie, Jens(?),
+    …, Richard and Scott, with brief introductions for each
+-   Working on (better) runner/integration for PhantomJS, [needs to
+    adapt to latest API
+    changes](http://code.google.com/p/phantomjs/issues/detail?id=171)
+

--- a/minutes/testing/2011-07-30.md
+++ b/minutes/testing/2011-07-30.md
@@ -1,0 +1,14 @@
+-   Ben Boyle prototyping Getting Started page for
+    site: [http://dev.benboyle.id.au/qunit/](http://dev.benboyle.id.au/qunit/)
+-   Subsuite runner (aka composite runner, runs a bunch of testsuite at
+    once and outputs detailed results in the familiar interface) is work
+    in
+    progress: [https://github.com/jquery/qunit/pull/131](https://github.com/jquery/qunit/pull/131)
+-   Chatted with John Bender (now at Adobe) for recruiting for testing
+    team, focus on addon for state
+    management [https://github.com/jquery/qunit/issues/120](https://github.com/jquery/qunit/issues/120) and
+    timing
+    helpers [https://github.com/jquery/qunit/issues/121](https://github.com/jquery/qunit/issues/121)
+-   Jonathan Buchanan commented on CLI integration, needs
+    review: [http://jquerytesting.pbworks.com/w/page/41615571/QUnit%20CLI%20Integration](http://jquerytesting.pbworks.com/w/page/41615571/QUnit%20CLI%20Integration)
+

--- a/minutes/testing/2011-10-07.md
+++ b/minutes/testing/2011-10-07.md
@@ -1,0 +1,3 @@
+Released QUnit 1.0.0 and created a Twitter account to do that and other
+announcements: [http://twitter.com/qunitjs](http://twitter.com/qunitjs)
+(106 followers so far!)

--- a/minutes/testing/2011-10-14.md
+++ b/minutes/testing/2011-10-14.md
@@ -1,0 +1,28 @@
+QUnit:
+
+-   Added window.onerror handler, catches errors outside QUnit's
+    try-catch blog, both within and outside the scope of a test
+-   Improved jsDump's handling of arrays and array-like objects. Solved
+    issue in Safari with outputting NodeList objects
+-   Released 1.1.0,
+    tag: [https://github.com/jquery/qunit/tree/1.1.0](https://github.com/jquery/qunit/tree/1.1.0),
+    changelog: [https://github.com/jquery/qunit/blob/1.1.0/History.md](https://github.com/jquery/qunit/blob/1.1.0/History.md)
+-   [qunitjs.com](http://qunitjs.com): Tested integrating new jQuery
+    theme into
+    Octopress: [http://bassistance.de/i/d9524d.png](http://bassistance.de/i/d9524d.png)
+
+TestSwarm:
+
+-   Added Firefox 7
+-   Added IE10 as Beta
+
+Integration
+
+-   Integrated PhantomJS running QUnit tests into Jenkins, updated
+    script
+    here: [https://github.com/jquery/qunit/blob/cli-phantomjs/test.js](https://github.com/jquery/qunit/blob/cli-phantomjs/test.js)
+-   QUnit green on Jenkins
+    build: [http://swarm.jquery.org:8080/](http://swarm.jquery.org:8080/)
+-   BrowserStack commited to providing TestSwarm clients by end of
+    October, mobile clients in about two months
+

--- a/minutes/testing/2011-10-24.md
+++ b/minutes/testing/2011-10-24.md
@@ -1,0 +1,6 @@
+An Octopress-based site and deployment is in place, deploying
+to [http://qunitjs.com/](http://qunitjs.com/) - the source repository is
+at [https://github.com/jquery/web-qunitjs-com-source](https://github.com/jquery/web-qunitjs-com-source) -
+used to edit theme, content and track issues. If you wanna contribute,
+check out the [open
+issues](https://github.com/jquery/web-qunitjs-com-source/issues).

--- a/minutes/testing/2011-10-29.md
+++ b/minutes/testing/2011-10-29.md
@@ -1,0 +1,3 @@
+No repo updates. Ben started working on Octopress-based site. Working
+with Doug to get QUnit-specific swatch and logo, needs something that
+overlaps less with jQuery Mobile.

--- a/minutes/testing/2011-11-05.md
+++ b/minutes/testing/2011-11-05.md
@@ -1,0 +1,10 @@
+Quite week for QUnit. Document some long-existing issues in tracker:
+
+[https://github.com/jquery/qunit/issues/171](https://github.com/jquery/qunit/issues/171)  
+
+[https://github.com/jquery/qunit/issues/172](https://github.com/jquery/qunit/issues/172)  
+
+[https://github.com/jquery/qunit/issues/173](https://github.com/jquery/qunit/issues/173)
+
+Progress on [qunitjs.com](http://qunitjs.com) halted, need to figure out
+how to get the design updated without wating for Doug.

--- a/minutes/testing/2011-11-18.md
+++ b/minutes/testing/2011-11-18.md
@@ -1,0 +1,9 @@
+Collaboration with BrowserStack is productive, jQuery Board got
+accounts, working on integrating that with TestSwarm, with Scott
+González leading that effort.
+
+Working with Jonathan Sharp on improving jquery-mockjax
+([https://github.com/appendto/jquery-mockjax/](https://github.com/appendto/jquery-mockjax/)).
+Moved docs to README on GitHub repo, integrated API docs there.
+Testsuite is much better shape, working with a few collaborators on
+fixes and enhancements.

--- a/minutes/testing/2011-11-25.md
+++ b/minutes/testing/2011-11-25.md
@@ -1,0 +1,1 @@
+Released QUnit v1.2.0.

--- a/minutes/testing/2011-12-02.md
+++ b/minutes/testing/2011-12-02.md
@@ -1,0 +1,2 @@
+Work in progress on the new site. Base template now has QUnit specific
+styles, content is coming together.

--- a/minutes/testing/2012-01-20.md
+++ b/minutes/testing/2012-01-20.md
@@ -1,0 +1,8 @@
+Improving the testing infrastructure: BrowserStack integration is in
+place, though various quirks still need to be ironed out. Improvements
+of the TestSwarm output in Jenkins jobs is under way.
+
+To focus efforts, the jQuery Mobile Jenkin's jobs are to be migrated
+over to our (mt) hosted instance. They'll keep using Ruby/Selenium for
+now, with the goal of migrating to the same TestSwarm/BrowserStack setup
+as the other projects over the next months.

--- a/minutes/testing/2012-02-17.md
+++ b/minutes/testing/2012-02-17.md
@@ -1,0 +1,5 @@
+Closed a big bunch of QUnit tickets this week, closing most pull
+requests and almost all bug tickets. New release coming up soon.
+
+Also working on the QUnit site again, [custom footer in theme already
+done](https://github.com/jquery/web-base-template/commit/628ca854c143a54fdcd4ec90a984989b735ddcb7).

--- a/minutes/testing/2012-02-26.md
+++ b/minutes/testing/2012-02-26.md
@@ -1,0 +1,2 @@
+Released QUnit
+v1.3.0: [https://github.com/jquery/qunit/blob/v1.3.0/History.md](https://github.com/jquery/qunit/blob/v1.3.0/History.md)

--- a/minutes/testing/2012-03-05.md
+++ b/minutes/testing/2012-03-05.md
@@ -1,0 +1,5 @@
+Had the first QUnit IRC meeting this week, going through most open
+tickets to figure out what to focus on. Some, like simulating events,
+still need a lot more thinking and input, others will get addressed over
+the next days/weeks. Will do a followup meeting, probably at the same
+time (Thursday, noon EST).

--- a/minutes/testing/2012-03-12.md
+++ b/minutes/testing/2012-03-12.md
@@ -1,0 +1,5 @@
+[Released QUnit 1.4.0](https://github.com/jquery/qunit/tree/v1.4.0)
+([Changelog](https://github.com/jquery/qunit/blob/v1.4.0/History.md))
+
+Working on the Jenkins-TestSwarm integration, [updated Hot Deploy
+guide](http://jquerytesting.pbworks.com/w/page/47944122/Hot%20Deploy%20Jenkins-Testswarm%20Plugin).

--- a/minutes/testing/2012-03-30.md
+++ b/minutes/testing/2012-03-30.md
@@ -1,0 +1,7 @@
+A few small fixes landed in QUnit: The testresult element now displays
+what test is currently running, which helps with lots of async test and
+“Hide passed tests” enabled. Update grunt.js to latest Grunt version.
+
+Lots of work in progress on TestSwarm, thanks to Timo ‘Krinkle’ Tijhof.
+Still working on [refactoring to page/action
+structure](https://github.com/jquery/testswarm/issues/132).

--- a/minutes/testing/2012-04-07.md
+++ b/minutes/testing/2012-04-07.md
@@ -1,0 +1,12 @@
+Released QUnit 1.5.0:
+
+\* Modify “Running…” to display test name. Fixes \#220  
+ \* Fixed clearing of sessionStorage in Firefox 3.6.  
+ \* Fixes \#217 by calling “block” with config.current.testEnvironment  
+ \* Add stats results to data. QUnit.jUnitReport function take one
+argument { xml:’ \* Add link to MDN about stack property
+
+Krinkle working on TestSwarm, integrating phpbrowscap to replace
+manually updated useragents in database with external list,
+automatically updated. Overhauled theme using Twitter’s Bootstrap.
+Getting close to 0.3.0 release.

--- a/minutes/testing/2012-04-27.md
+++ b/minutes/testing/2012-04-27.md
@@ -1,0 +1,16 @@
+QUnit’s [composite
+addon](https://github.com/jquery/qunit/tree/master/addons/composite) is
+now using the new callback registration mechanism, making it a lot more
+compatible with other code using those callbacks. Rerun links to open
+the individual testsuite.
+
+The QUnit website is coming together, with a docpad-based repo at
+[https://github.com/jquery/qunitjs.com](https://github.com/jquery/qunitjs.com).
+Contributions welcome! For now this is deployed via GitHub pages at
+qunitjs.com, but will soon migrate to the WordPress-based deployment
+that all other jQuery properties will use.
+
+TestSwarm 1.0 is basically done, but still waits for updates on
+BrowserStack and Jenkins integrations. Once those are done, TestSwarm
+1.0 will be official. In the meantime, we’ve revived the [@TestSwarm
+Twitter account](https://twitter.com/testswarm).

--- a/minutes/testing/2012-05-04.md
+++ b/minutes/testing/2012-05-04.md
@@ -1,0 +1,22 @@
+QUnit 1.6.0 was released, featuring a stable composite addon, a few bug
+fixes and enhancements. [More details in the
+changelog](https://github.com/jquery/qunit/blob/v1.6.0/History.md).
+
+[swarm.jquery.org](http://swarm.jquery.org/) is now running TestSwarm
+1.0.0.
+
+Jenkins integration is now done via
+[node-testswarm](https://github.com/jzaefferer/node-testswarm), making
+improvements a lot easier and moving configurations into the individual
+projects. That makes them also a lot less dependent on Jenkins itself.
+
+[TestSwarm-BrowserStack](https://github.com/clarkbox/testswarm-browserstack)
+is now using the TestSwarm 1.0.0 API, removing the dependency on
+auto-increment IDs. Its also gotten better at dealing with BrowserStack
+queue limits, making more efficient use of their service. The module now
+has more documentation, making it easier to use for other projects.
+
+Krinkle wrote [Automated Distributed Continuous Integration for
+JavaScript](https://github.com/jquery/testswarm/wiki/Automated-Distributed-Continuous-Integration-for-JavaScript),
+outlining how to combine all these various projects into one whole
+automation setup.

--- a/minutes/testing/2012-06-01.md
+++ b/minutes/testing/2012-06-01.md
@@ -1,0 +1,6 @@
+Second QUnit meeting happened on Thursday. The focus was on triaging all
+existing tickets. In the process we closed a few as invalid, fixed two
+with actual code changes, and clarified a few other.  Documentation
+tickets will be handled once the [qunitjs.com](http://qunitjs.com) site
+is a little further. Once module filtering and their visual display is
+improved, 1.7.0 is ready for release.

--- a/minutes/testing/2012-06-07.md
+++ b/minutes/testing/2012-06-07.md
@@ -1,0 +1,25 @@
+Released QUnit 1.7.0! There's now [an official phantomjs runner
+addon](https://github.com/jquery/qunit/tree/master/addons/phantomjs),
+stack traces are much more useful (more lines if available), and various
+other small improvements. From the changelog:
+
+-   Add config.requireExpects. Fixes \#207 – Add option to require all
+    tests to call expect().
+-   Improve extractStacktrace() implementation. Fixes \#254 – Include
+    all relevant stack lines
+-   Make filters case-insensitive. Partial fix for \#252
+-   is() expects lowercase types. Fixes \#250 – Expected Date value is
+    not displayed properly
+-   Fix phantomjs addon header and add readme. Fixes \#239
+-   Add some hints to composite addon readme. Fixes \#251
+-   Track tests by the order in which they were run and create rerun
+    links based on that number. Fixes \#241 – Make Rerun link run only a
+    single test.
+-   Use QUnit.push for raises implementation. Fixes \#243
+-   CLI runner for phantomjs
+-   Fix jshint validation until they deal with /\*\* \*/ comments
+    properly
+-   Update validTest() : Simplify logic, clarify vars and add comments
+-   Refactor assertion helpers into QUnit.assert (backwards compatible)
+-   Add Rerun link to placeholders. Fixes \#240
+

--- a/minutes/testing/2012-06-15.md
+++ b/minutes/testing/2012-06-15.md
@@ -1,0 +1,9 @@
+****
+
+-   QUnit 1.8.0 is out
+-   TestSwarm is getting better one small step at a time.
+-   Dual clone’s are gone everywhere, speeds up a job for a few seconds,
+    and will help to doing -git CDN deploys
+-   Deployed John Bender's grunt-junit plugin to jQuery UI job
+
+

--- a/minutes/testing/2012-06-21.md
+++ b/minutes/testing/2012-06-21.md
@@ -1,0 +1,54 @@
+The first testing and CI meeting happened today, and will continue to
+happen bi-weekly, Thursday at Noon EST. Here’s the agenda and meeting
+notes.
+
+June 21, 2012  
+
+Location: \#jquery-meeting on Freenode
+
+Attending: Corey, John Bender, Jörn
+
+Time: Noon ET
+
+QUnit
+
+-   Website on staging is working with iframes
+-   No major open issues:
+    [https://github.com/jquery/qunit/issues](https://github.com/jquery/qunit/issues)
+-   Rerun link for modules, to set module=… filter, should land in the
+    next release:
+    [https://github.com/jquery/qunit/issues/246](https://github.com/jquery/qunit/issues/246)
+
+TestSwarm
+
+-   Milestone 1.0.0 still shifting, but getting closer:
+    [https://github.com/jquery/testswarm/issues?milestone=1&state=open](https://github.com/jquery/testswarm/issues?milestone=1&state=open)
+-   Krinkle experimented with opening a window instead of embedding
+    iframes, mostly to address iframe-measuring issues in jQuery Core
+    testsuite:
+    [https://github.com/jquery/testswarm/issues/195](https://github.com/jquery/testswarm/issues/195)
+-   Color, UI and QUnit jobs are solid, Core still has a few issues,
+    Mobile isn’t on TestSwarm yet. Should start experimenting with that
+    sometime soon.
+
+Jenkins integration
+
+Deploying -git builds for Core, UI, QUnit and Mobile, though no
+consistent headers yet, and a very different setup for Mobile
+
+Get sizzle on Jenkins and TestSwarm
+
+-   Added grunt.js, will create job to run \`lint\` test once that is
+    fixed
+
+Perf regression testing
+
+-   John Bender to explore this
+
+Move to new service box
+
+-   Sometime after the conference
+-   Will remove \`scp\` step from git-build
+-   Ask Clark to help with that, he can invest a few hours
+
+ 

--- a/minutes/testing/2012-07-19.md
+++ b/minutes/testing/2012-07-19.md
@@ -1,0 +1,63 @@
+**July 19, 2012**
+
+Location: \#jquery-meeting on Freenode
+
+Attending: Jörn, Timo, Scott
+
+Time: Noon ET
+
+ 
+
+QUnit
+
+-   Released v1.9.0!  
+
+    [https://github.com/jquery/qunit/blob/master/History.md\#190–2012-07-11](https://github.com/jquery/qunit/blob/master/History.md#190--2012-07-11)
+
+TestSwarm
+
+-   Experiment with test-running in new windows instead of iframes has
+    been completed[. Details at
+    https://github.com/jquery/testswarm/issues/195](https://github.com/jquery/testswarm/issues/195.).
+    Long story short: popups are worse than iframes, we’ll have to stick
+    with iframes for now and instead let those bugs depend on the
+    implementation of the new “in-host” system where we don’t use a
+    frame-relationship with a constant long-lived “run page”.
+
+Jenkins integration
+
+-   botio integration stalled until EOL servers are dealt with
+-   See also “Perf regression testing”
+
+Perf regression testing
+
+There’s two parts to perf testing. One is the performance of a regular
+test suite run, to catch overall issues and slowness:
+
+-   We’re going to implement a json report aside from the html-snapshot
+    report of each test run
+-   Aside from the assertion results, we’re going to add the test
+    duration of each test
+-   in Jenkins we will use that json report to form an “jUnit Ant XML”
+    report card, so that Jenkins will generate historic graphs for each
+    job with the performance over time of each project as a whole, as
+    well as each individual module, test and assertion.
+
+The other is dedicated jsperf-like testing with repetition of certain
+specific tasks that should perform well. This likely requires the
+introduction of a framework or plugin in addition to core QUnit.
+
+Move to new service box
+
+gnarf has given krinkle access to jq03. Right now just has a fresh
+testswarm clone, nothing is set up yet. Krinkle intends to set up and
+document and/or puppetize it over the coming 1-2 weeks. If it needs to
+happen earlier, he is willing to document is somewhere and have someone
+else implement it (most if not all is documented very well at
+[https://github.com/jquery/testswarm/wiki/Automated-Distributed-Continuous-Integration-for-JavaScript](https://github.com/jquery/testswarm/wiki/Automated-Distributed-Continuous-Integration-for-JavaScript)
+)
+
+-   Update: Some internal details at
+    [https://github.com/jquery/infrastructure/wiki/TestSwarm:-Install-&-Upgrade](https://github.com/jquery/infrastructure/wiki/TestSwarm:-Install-&-Upgrade)
+
+ 

--- a/minutes/testing/2012-08-03.md
+++ b/minutes/testing/2012-08-03.md
@@ -1,0 +1,50 @@
+**August 2, 2012  
+**
+
+Location: \#jquery-meeting on Freenode
+
+Attending: Corey, Scott, Dave, John, Jörn
+
+Time: Noon ET
+
+QUnit
+
+Need to review [pull requests](https://github.com/jquery/qunit/pulls)
+and other [issues](https://github.com/jquery/qunit/issues)
+
+-   [\#287](https://github.com/jquery/qunit/pull/287) will land module
+    select after some cleanup
+-   [\#289](https://github.com/jquery/qunit/pull/289) look into
+    enhancing validTest to always accept global failure
+-   [\#292](https://github.com/jquery/qunit/pull/292) move .html() reset
+    to Core (and maybe UI)
+-   [\#291](https://github.com/jquery/qunit/issues/291#issuecomment-7460089)
+    looks invalid
+
+TestSwarm
+
+BrowserStack running better now, all UI jobs green without us changing
+anything
+
+Corey working on post-commit hooks, will use those for testswarm and
+testswarm-browserstack to deploy updates in the future
+
+John Bender working on getting Mobile fixed in IE9, a few (swarm)
+heisenbugs make that not as much fun
+
+Need to move testswarm-browserstack to jquery account, use Krinkle’s
+fork as starting point. Ask Clark though to move his repo to keep forks
+and issues.
+
+-   Merge Corey’s experiments, see
+    /usr/local/tools/testswarm-browserstack/gnarf-test.js
+    on[jq03.jquery.com](http://jq03.jquery.com/)
+-   Also look into upgrading to v2 BrowserStack API, node-browserstack
+    already supports that
+
+Move to new service box
+
+-   Done, [swarm.jquery.org](http://swarm.jquery.org) running on new
+    server
+
+ 

--- a/minutes/testing/2012-08-16.md
+++ b/minutes/testing/2012-08-16.md
@@ -1,0 +1,45 @@
+**August 16, 2012  
+**
+
+Location: \#jquery-meeting on Freenode
+
+Attending: Scott, Dave, John, Rick, Jörn
+
+Time: Noon ET
+
+QUnit
+
+Landed module filter select. Now it is trivial to filter by module, so
+much more convenient.
+
+A few [PRs](https://github.com/jquery/qunit/pulls) and
+[issues](https://github.com/jquery/qunit/issues) to review
+
+-   [New PR 302 for cumulative
+    expect](https://github.com/jquery/qunit/pull/302) – makes
+    QUnit.expect() also a getter, but doesn’t change anything else.
+    Looks good, will land.
+-   [More info for callbacks, PR
+    300](https://github.com/jquery/qunit/pull/300) – closed
+-   Any reason to expose the Test object? [PR
+    293](https://github.com/jquery/qunit/pull/293) – not really, closed
+-   [Closed the server-people-dont-like-tests
+    PR](https://github.com/jquery/qunit/pull/295)
+-   Will look into implementing
+    [\#304](https://github.com/jquery/qunit/issues/304) – QUnit can do
+    more to restore scroll position, likely just scrolling back to top.
+-   Will look into implement
+    [\#279](https://github.com/jquery/qunit/issues/279)
+-   Closed [\#291 as
+    invalid](https://github.com/jquery/qunit/issues/291)
+-   Will land [\#289](https://github.com/jquery/qunit/pull/289) without
+    the kludgy test
+
+TestSwarm
+
+-   Jenkins/TestSwarm/BrowserStack running pretty stable, lots of green
+-   Maintaining browser mappings is annoying. Will get a little easier
+    once testswarm-browserstack is moved to jquery orga. Maybe a bit
+    more easier when moving TestSwarm to ua-parser.
+
+ 

--- a/minutes/testing/2012-08-30.md
+++ b/minutes/testing/2012-08-30.md
@@ -1,0 +1,33 @@
+**August 30, 2012**
+
+Location: \#jquery-meeting on Freenode
+
+Attending: Scott, Dave, John, Jörn
+
+Time: Noon ET
+
+QUnit
+
+1.10.0 is live! Core to update, UI updated, Mobile to update
+
+Will launch some nice updates for [qunitjs.com](http://qunitjs.com) and
+[api.qunitjs.com](http://api.qunitjs.com) today or tomorrow
+
+[PRs](https://github.com/jquery/qunit/pulls) and
+[issues](https://github.com/jquery/qunit/issues) to review
+
+-   [Parallel execution](https://github.com/jquery/qunit/issues/253) –
+    looking for ideas and prototypes – closed
+-   [Deprecate module](https://github.com/jquery/qunit/issues/190)? The
+    problem is bad environment detection.
+-   [Sandboxing](https://github.com/jquery/qunit/issues/173)? closed
+-   [Minimize html](https://github.com/jquery/qunit/issues/127) – does
+    this need more docs? Nope
+
+TestSwarm
+
+-   Timo is back. We should have updates soon.
+-   Core still has random ajax failures, Mobile is dealing with IE
+    issues
+
+ 

--- a/minutes/testing/2012-09-13.md
+++ b/minutes/testing/2012-09-13.md
@@ -1,0 +1,34 @@
+**September 13, 2012  
+**
+
+Location: \#jquery-meeting on Freenode
+
+Attending: Dave, Jörn, Richard, Corey, Scott
+
+Time: Noon ET
+
+QUnit
+
+1.10 works, core had to fix some issues where selectors weren’t scope to
+\#qunit-fixture
+
+[PRs](https://github.com/jquery/qunit/pulls) and
+[issues](https://github.com/jquery/qunit/issues) to review
+
+-   Still undecided on module naming, didn’t get any feedback from node
+    people:
+    [https://github.com/jquery/qunit/issues/190](https://github.com/jquery/qunit/issues/190)
+    – Scott to ping them again
+
+TestSwarm
+
+-   Richard to work on ua-parser ticket:
+    [https://github.com/jquery/testswarm/issues/187](https://github.com/jquery/testswarm/issues/187)
+-   Need to track down Timo
+
+mergatron
+
+-   Alternative to botio for testing Pull Requests
+
+Corey to stage that next week:
+[https://github.com/SnapInteractive/mergeatron](https://github.com/SnapInteractive/mergeatron)

--- a/minutes/testing/2012-09-28.md
+++ b/minutes/testing/2012-09-28.md
@@ -1,0 +1,52 @@
+**September 27, 2012**
+
+Location: \#jquery-meeting on Freenode
+
+Attending: Jörn, Richard, Timo
+
+Time: Noon ET
+
+ 
+
+QUnit
+
+[PRs](https://github.com/jquery/qunit/pulls) and
+[issues](https://github.com/jquery/qunit/issues) to review
+
+-   [\#317](https://github.com/jquery/qunit/issues/317#issuecomment-8849976)
+    is looking for an assertion method to compare objects with different
+    constructors
+-   [\#320](https://github.com/jquery/qunit/pull/320#issuecomment-8899658)
+    has an example of loading tests asynchronously. Recommendation is to
+    use autostart=false, then start(), to make that work. Other ideas?
+-   Will land [pull \#323](https://github.com/jquery/qunit/pull/323)
+    unless anyone has concerns – just quotes “throws” to make old
+    interpreters not throw up
+-   [\#326](https://github.com/jquery/qunit/issues/326) asks for in
+    “inconclusive” assertion, aka “needs a test”. Opinions?
+-   [\#314](https://github.com/jquery/qunit/issues/314#issuecomment-8302634)
+    – throw up or log a failed assertion when calling start() while
+    already running?
+-   Related to \#320 and \#314 is
+    [\#309](https://github.com/jquery/qunit/issues/309)
+
+TestSwarm
+
+-   Blog post about TestSwarm
+-   1.0 Roadmap
+-   web site in November? Also needs new logo:
+    [https://github.com/jquery/testswarm/issues/128](https://github.com/jquery/testswarm/issues/128)
+-   Timo is working on testswarm-browserstack rewrite, will land update
+    soon, makes it a lot more reliable
+-   Up next: Improve keep-alive to get rid of timed-out clients faster;
+    should make proper use of the ping-system implemented in TestSwarm
+    recently
+-   Richard still working on ua-parser ticket:
+    [https://github.com/jquery/testswarm/issues/187](https://github.com/jquery/testswarm/issues/187)
+
+botio/mergatron
+
+-   What’s the next step to start using that?
+-   We should integrate that with the Commit Status API:
+    [https://github.com/blog/1227-commit-status-api](https://github.com/blog/1227-commit-status-api)
+

--- a/minutes/testing/2012-10-25.md
+++ b/minutes/testing/2012-10-25.md
@@ -1,0 +1,20 @@
+**October 25, 2012**
+
+Location: \#jquery-meeting on Freenode
+
+Attending: Jörn, Dave, Scott
+
+Time: Noon ET
+
+QUnit
+
+-   A few [issues](https://github.com/jquery/qunit/issues) to review,
+    mostly feature ideas
+
+TestSwarm
+
+-   Create new browserSets for UI (no IE6) and Core 2.0 (no IE6, 7 and
+    8)
+-   Add IE10 and Safari 6
+
+ 

--- a/minutes/testing/2012-11-23.md
+++ b/minutes/testing/2012-11-23.md
@@ -1,0 +1,4 @@
+Making good progress towards TestSwarm 1.0 and BrowserStack/Jenkins
+integration. The switch to ua-parser is complete, allowing us to start
+testing against mobile browsers along with getting rid of a lot of
+maintenance overhead.

--- a/minutes/testing/2012-12-07.md
+++ b/minutes/testing/2012-12-07.md
@@ -1,0 +1,65 @@
+**December 6, 2012**
+
+Location: \#jquery-meeting on Freenode
+
+Attending: Scott, Corey, Jörn
+
+Time: Noon ET
+
+QUnit
+
+-   Working fine for us, not so great when tests are loaded async, e.g.
+    with requirejs:
+    [https://github.com/jquery/qunit/issues/358](https://github.com/jquery/qunit/issues/358)
+    – have QUnit.start() wait for QUnit.load (if there’s a dom), if
+    there’s none, init immediately. Wrap the DOM access in QUnit.init()
+    to make that also work without DOM.
+-   Deprecate/remove QUnit.reset?
+    [https://github.com/jquery/qunit/issues/354](https://github.com/jquery/qunit/issues/354)
+    – yes
+-   Deprecated/remove expect argument from test() and asyncTest()?
+    [https://github.com/jquery/qunit/issues/356](https://github.com/jquery/qunit/issues/356)
+    – yep
+-   Find a better diff implementation?
+    [https://github.com/jquery/qunit/issues/335](https://github.com/jquery/qunit/issues/335)
+    and
+    [https://github.com/jquery/qunit/issues/348](https://github.com/jquery/qunit/issues/348)
+    – will try jsdiff, along with a leaf-differ (\#363 and \#364)
+-   A bunch of PRs from JamesMGreen, needs review.
+-   Added diff label and two more tickets to try jsdiff and implement a
+    leaf-differ:
+    [https://github.com/jquery/qunit/issues?labels=diff&page=1&state=open](https://github.com/jquery/qunit/issues?labels=diff&page=1&state=open)
+-   
+
+TestSwarm
+
+-   Lots of trouble with BrowserStack lately. Apparently their broken
+    VMs only get fixed when we report the issue. Corey got IE7 and
+    Safari 6 VMs fixed
+-   A few jobs, especially in IE8 fail to submit results with “”Error
+    connecting to server”
+-   TestSwarm rewrite well on the way. Is now using ua-parser, much less
+    maintenance in TestSwarm itself and testswarm-browserstack.
+
+testswarm-browserstack
+
+-   Rewrite finished. Much less maintenance required here as well. More
+    advanced and machine-readable log output (Splunk!) and smarter
+    worker spawn management, and more (see commit log for more details).
+
+Mergeatron
+
+Experimenting for jquery core
+
+-   To be moved to a separate testswarm account
+-   Refactor grunt-testswarm to not need changes for mergeatron/PR.
+
+Jenkins builds are put in directory /build/\<project\>/PR-\<\#\>. This
+is a problem as those are non-unique (more than 1 commit per PR). Should
+use the commit hash like we do for other builds. Though builds are
+synchronous, a run can be reset later in time. If the directory has
+changed, the re-run will be incorrect.
+
+-   Also, job name: “pull \#123” -\> “pull \#123 – commit \#af04”.
+
+ 

--- a/minutes/testing/2012-12-21.md
+++ b/minutes/testing/2012-12-21.md
@@ -1,0 +1,33 @@
+****December 20, 2012****
+
+********Location: \#jquery-meeting on Freenode
+
+Attending: Scott, Dave, Rodney, Jörn
+
+Time: 11am ET (16:00 UTC)
+
+ 
+
+QUnit
+
+[\#378 – codebase split](https://github.com/jquery/qunit/issues/378). If
+so, how? Follow jQuery Core? UMD/AMD?
+
+-   Check out what James suggested (lodash UMD), otherwise just copy
+    approach from Core, release single file on CDN and NPM
+
+[\#352 – Unsafe JavaScript attempt to access
+frame](https://github.com/jquery/qunit/issues/352) – what is going on?
+
+[\#347 – Add assertion to run after loading source to look for
+globals](https://github.com/jquery/qunit/issues/347#issuecomment-11479580)
+– add a resource loader to QUnit? Would need a prototype. The
+global-leaks check doesn’t seem worth the trouble though.
+
+TestSwarm
+
+-   Timo sent [PR to update
+    node-testswarm](https://github.com/jzaefferer/node-testswarm/pull/7)
+-   [Need to get rid of iframe for running
+    tests](https://github.com/jquery/testswarm/issues/195)
+-   

--- a/minutes/testing/2013-01-05.md
+++ b/minutes/testing/2013-01-05.md
@@ -1,0 +1,61 @@
+January 03, 2013
+
+Location: \#jquery-meeting on Freenode
+
+Attending: James, Jörn
+
+Time: 11am ET (16:00 UTC)
+
+QUnit
+
+Survey is online:
+[https://docs.google.com/spreadsheet/viewform?formkey=dDBzQl9TWmQzbDdXS08wMTBuLTlObXc6MQ\#gid=0](https://docs.google.com/spreadsheet/viewform?formkey=dDBzQl9TWmQzbDdXS08wMTBuLTlObXc6MQ#gid=0)
+
+Survey results:
+[https://docs.google.com/spreadsheet/ccc?key=0ArIM4UVbwE-3dDBzQl9TWmQzbDdXS08wMTBuLTlObXc\#gid=0](https://docs.google.com/spreadsheet/ccc?key=0ArIM4UVbwE-3dDBzQl9TWmQzbDdXS08wMTBuLTlObXc#gid=0)
+
+Updated htmlEqual PR from James:
+[https://github.com/jquery/qunit/pull/368](https://github.com/jquery/qunit/pull/368)
+– needs review
+
+Landed
+[https://github.com/jquery/qunit/pull/387](https://github.com/jquery/qunit/pull/387)
+– more reliable throws() assertion
+
+Landed
+[https://github.com/jquery/qunit/pull/384](https://github.com/jquery/qunit/pull/384)
+– module/test filters now work in IE7/8 with file protocol
+
+Support for pending tests like Mocha? “tests without a function body
+such that they show up in the list but have a different visual
+representation and do not count as either a success or a failure;
+rather, a new "pending" count is added as well.” – still not very
+convincing.
+
+Better async testing!
+
+Mocha looks at callback signature and makes tests async when a callback
+argument, usually named done, is present:
+[http://visionmedia.github.com/mocha/\#asynchronous-code](http://visionmedia.github.com/mocha/#asynchronous-code)
+
+Can’t do that since we introduced the assert argument
+
+Can do something like this:
+
+-   test(…, function(assert) { var done = assert.async(); … done(); }
+-   asyncTest(…, function(assert) { assert.done(); })
+
+Going to land the two deprecation tickets, then release 1.11
+
+-   [https://github.com/jquery/qunit/issues/354](https://github.com/jquery/qunit/issues/354)
+-   [https://github.com/jquery/qunit/issues/356](https://github.com/jquery/qunit/issues/356)
+
+TestSwarm
+
+-   Landed Timo’s [PR to update
+    node-testswarm](https://github.com/jzaefferer/node-testswarm/pull/7)
+    – published [testswarm@1.0.0](mailto:testswarm@1.0.0)-alpha. Sane
+    API, reporters, bug fixes.
+-   [Need to get rid of iframe for running
+    tests](https://github.com/jquery/testswarm/issues/195)
+

--- a/minutes/testing/2013-01-31.md
+++ b/minutes/testing/2013-01-31.md
@@ -1,0 +1,51 @@
+January 31, 2013
+
+Location: \#jquery-meeting on Freenode
+
+  
+ Attending: Scott, Richard, Corey, James, Jörn  
+  
+ Time: 11am ET (16:00 UTC)  
+  
+   
+  
+
+QUnit
+
+-   Explicit ordering of module  
+     names?
+    [https://github.com/jquery/qunit/pull/392](https://github.com/jquery/qunit/pull/392)  
+     - wil land that
+-   Need to add (CI) tests for  
+     non-browser enviroments and fix the regression there:
+    [https://github.com/jquery/qunit/pull/401](https://github.com/jquery/qunit/pull/401)
+-   Issues with QUnit.equiv and  
+     circular references:
+    [https://github.com/jquery/qunit/issues/397](https://github.com/jquery/qunit/issues/397)  
+     - gnarf looking at this
+-   James working on Composite addon.  
+     Trying to get rid of some hacks. May need to expose some more
+    QUnit  
+     internals.
+-   69 replies to the survey, will  
+     process the results in the next days. Big points: Most people don’t
+    know  
+     about add-ons. A lot of people are interested in CI tools.
+
+TestSwarm
+
+-   Timo working on projects  
+     refactoring
+-   Puppetized localSettings.json, no  
+     more edit-on-live server when we need to change our browset sets.
+
+BrowserStack integration
+
+-   Got BrowserStack access to our Splunk  
+     dashboard. Already helping to fix issues on their end.
+-   Now hoping to figure out why we  
+     loose so many workers.
+
+ 
+
+ 

--- a/minutes/testing/2013-02-28.md
+++ b/minutes/testing/2013-02-28.md
@@ -1,0 +1,30 @@
+**February 28, 2013**  
+ Location: \#jquery-meeting on Freenode  
+ Attending: Timo, Dave, Scott, Jörn  
+ Time: 11am ET (16:00 UTC)
+
+QUnit
+
+Starting splitting out add-ons  
+ into separate repositories:
+
+-   [https://github.com/jquery/qunit-contrib-composite/](https://github.com/jquery/qunit-contrib-composite/)
+-   [https://github.com/jquery/qunit-reporter-junit](https://github.com/jquery/qunit-reporter-junit)
+
+TestSwarm
+
+Timo working on projects  
+ refactoring:
+[https://github.com/jquery/testswarm/tree/projects-4](https://github.com/jquery/testswarm/tree/projects-4)  
+
+Working with BrowserStack to fix  
+ lost workers.
+
+-   jq03 should be more stable:
+    [https://github.com/jquery/infrastructure/issues/145\#issuecomment-14226261](https://github.com/jquery/infrastructure/issues/145#issuecomment-14226261)
+-   Asked them to get rid of flash/firebug.xml  
+     “feature” causing Windows Firefox to crash
+
+ 
+
+ 

--- a/minutes/testing/2013-03-14.md
+++ b/minutes/testing/2013-03-14.md
@@ -1,25 +1,64 @@
-* Attending: James, Scott, Ghislain, Jörn, Richard, Timo
+**March 14, 2013**  
+ Location: \#jquery-meeting on Freenode  
+ Attending: James, Scott, Ghislain, Jörn, Richard, Timo
 
-## QUnit
-* qunit-reporter-junit in its own repo, running current grunt, built by Travis-CI
-* composite addon updated in master ( https://github.com/jquery/qunit/pull/408 )
-  - James will move to its own repo soon
-* Discussing replacing callbacks with events: https://github.com/jquery/qunit/issues/422
-  - Timo to work on that
-* Refactored assertion addons, add assertions to QUnit.assert ( https://github.com/jquery/qunit/pull/418 )
-* Update QUnit to grunt 0.4 ( https://github.com/jquery/qunit/pull/423 )
-* add-on vs plugin vs extension?
-  - Let’s go with plugin. And publish them to npm.
-* Browser support for QUnit ( https://github.com/jquery/qunit/issues/412 ) vs plugins? Should they match? Will jQuery 1.x support IE6 forever?
-* We’ll keep the PhantomJS plugin: https://github.com/jquery/qunit/issues/420#issuecomment-14909617
+Time: 11am ET (16:00 UTC)
 
-## Jenkins/Travis
-* We’d like to run `grunt` for all PRs – Travis makes this really easy, mergatron should do it, too.
-* We want TestSwarm for regular commits, this won’t work with Travis, since it can’t expose confidential credentials to PR committers.
-* TODO: Add a few more projects to Travis, gives us basic testing for PRs
-  - travis.yml to init/update submodules, npm install -g grunt-cli
-  - npm install && npm test is done on travis by default
-* We can use that at least until mergatron can do it better.
+QUnit
 
-## TestSwarm
-* projects update shelved for a week, until higher priority issues are resolved (infrastructure, BrowserStack)
+-   qunit-reporter-junit in its own  
+     repo, running current grunt, built by Travis-CI
+-   composite addon updated in master  
+     (
+    [https://github.com/jquery/qunit/pull/408](https://github.com/jquery/qunit/pull/408)  
+     ), James will move to its own repo soon
+-   Discussing replacing callbacks  
+     with events:
+    [https://github.com/jquery/qunit/issues/422](https://github.com/jquery/qunit/issues/422)  
+     - Timo to work on that
+-   Refactored assertion addons, add  
+     assertions to QUnit.assert (
+    [https://github.com/jquery/qunit/pull/418](https://github.com/jquery/qunit/pull/418)  
+     )
+-   Update QUnit to grunt 0.4 (
+    [https://github.com/jquery/qunit/pull/423](https://github.com/jquery/qunit/pull/423)  
+     )
+-   add-on vs plugin vs extension?  
+     Let’s go with **plugin**. And publish them to npm.
+-   Browser support for QUnit (
+    [https://github.com/jquery/qunit/issues/412](https://github.com/jquery/qunit/issues/412)
+    ) vs  
+     plugins? Should they match? Will jQuery 1.x support IE6 forever?
+-   We’ll keep the PhantomJS plugin:
+    [https://github.com/jquery/qunit/issues/420\#issuecomment-14909617](https://github.com/jquery/qunit/issues/420#issuecomment-14909617)
+
+Jenkins/Travis
+
+We’d like to run \`grunt\` for all  
+ PRs – Travis makes this really easy, mergatron should do it, too.
+
+We want TestSwarm for regular  
+ commits, this won’t work with Travis, since it can’t expose
+confidential  
+ credentials to PR committers.
+
+TODO: Add a few more projects to  
+ Travis, gives us basic testing for PRs
+
+-   travis.yml to init/update  
+     submodules, npm install -g grunt-cli
+-   npm install && npm test  
+     is done on travis by default
+
+We can use that at least until  
+ mergatron can do it better.
+
+TestSwarm
+
+-   projects update shelved for a  
+     week, until higher priority issues are resolved (infrastructure,  
+     BrowserStack)
+
+ 
+
+ 


### PR DESCRIPTION
Since both core and testing had between 50 and 70 meeting notes to be imported, [I wrote a script](https://gist.github.com/jzaefferer/5677000) that took the atom feed, went through all pages, extracted the content, converted it to markdown, and wrote that to disk.

This PR is the result of that script. There was one duplicate testing post, which I reverted, to keep the manually edited one. Otherwise this is the unedited output of my script. It's not perfect, but the hour it took to write that script seems like a better investment then to import all those manually.
