### PR TITLE
Build: Remove jQuery from team name

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,7 +31,7 @@ jqueryContent.postPreprocessors.post = (function() {
 	var teamNames = {};
 
 	taxonomies.category.forEach(function( category ) {
-		teamNames[ category.slug ] = "jQuery " + category.name;
+		teamNames[ category.slug ] = category.name;
 	});
 
 	return function( post, postPath, callback ) {


### PR DESCRIPTION
We added 'jQuery' to some of the category names so it needs to be removed from the team name or we end up with 'jQuery jQuery' for core, ui, mobile and content. 